### PR TITLE
Feat/Pulse modifications allowing pulses to be attached to non-channel components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 ## [Unreleased]
 ### Added
 - Added InOutSingleChannel
@@ -6,6 +7,12 @@
 ### Changed
 - Changed `InOutIQChannel.input_offset_I/Q` to `InOutIQChannel.opx_input_offset_I/Q`
 - Renamed `SingleChannel.output_offset` -> `SingleChannel.opx_output_offset`
+- Pulse behaviour modifications to allow pulses to be attached to objects other than channels. Changes conist of following components
+  - Added `pulse.channel`, which returns None if both its parent & grandparent is not a `Channel`
+  - Rename `Pulse.full_name` -> `Pulse.name`.
+    Raises error if `Pulse.channel` is None
+    TODO Check if this causes issues
+  - `Pulse.apply_to_config` does nothing if pulse has no channel
 
 ### Fixed
 - Don't raise instantiation error when required_type is not a class

--- a/tests/components/test_pulses.py
+++ b/tests/components/test_pulses.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from quam.core import *
 from quam.components import *
 from quam.components.channels import Channel, IQChannel, SingleChannel
 
@@ -127,3 +128,22 @@ def test_IQ_pulse_play_validate():
 
     with pytest.raises(IndexError):
         single_channel.play("X180")
+
+
+def test_pulse_parent_channel():
+    pulse = pulses.SquarePulse(length=60, amplitude=0)
+    assert pulse.parent is None
+    assert pulse.channel is None
+
+    channel = SingleChannel(id="single", opx_output=0)
+    pulse.parent = channel
+    assert pulse.parent is channel
+    assert pulse.channel is channel
+
+
+def test_pulse_parent_parent_channel():
+    pulse = pulses.SquarePulse(length=60, amplitude=0)
+    channel = SingleChannel(id="single", opx_output=0)
+    channel.operations["pulse"] = pulse
+    assert pulse.parent is channel.operations
+    assert pulse.channel is channel


### PR DESCRIPTION
Pulse behaviour modifications to allow pulses to be attached to objects other than channels. Changes conist of following components
  - Added `pulse.channel`, which returns None if both its parent & grandparent is not a `Channel`
  - Rename `Pulse.full_name` -> `Pulse.name`.
    Raises error if `Pulse.channel` is None
    TODO Check if this causes issues
  - `Pulse.apply_to_config` does nothing if pulse has no channel

Necessary for #4 