### PR TITLE
Fix: Add final action for setting offset of LF-FEM analog output port.

### DIFF
--- a/quam/utils/config.py
+++ b/quam/utils/config.py
@@ -10,16 +10,15 @@ def generate_config_final_actions(qua_config):
     Args:
         qua_config (dict): The generated qua config.
     """
+    # Add default dc offset 0V to all analog outputs and inputs if not set
     for controller_cfg in qua_config["controllers"].values():
-        if "fems" in controller_cfg:
-            for fem in controller_cfg["fems"].values():
-                if fem.get("type") == "LF":
-                    if "analog_outputs" in fem:
-                        for analog_output in fem["analog_outputs"].values():
-                            analog_output.setdefault("offset", 0.0)
-                    if "analog_inputs" in fem:
-                        for analog_input in fem["analog_inputs"].values():
-                            analog_input.setdefault("offset", 0.0)
+        for fem in controller_cfg.get("fems", {}).values():
+            if fem.get("type") != "LF":
+                continue
+            for analog_output in fem.get("analog_outputs", {}).values():
+                analog_output.setdefault("offset", 0.0)
+            for analog_input in fem.get("analog_inputs", {}).values():
+                analog_input.setdefault("offset", 0.0)
 
         if "analog_outputs" in controller_cfg:
             for analog_output in controller_cfg["analog_outputs"].values():

--- a/quam/utils/config.py
+++ b/quam/utils/config.py
@@ -11,6 +11,16 @@ def generate_config_final_actions(qua_config):
         qua_config (dict): The generated qua config.
     """
     for controller_cfg in qua_config["controllers"].values():
+        if "fems" in controller_cfg:
+            for fem in controller_cfg["fems"].values():
+                if fem.get("type") == "LF":
+                    if "analog_outputs" in fem:
+                        for analog_output in fem["analog_outputs"].values():
+                            analog_output.setdefault("offset", 0.0)
+                    if "analog_inputs" in fem:
+                        for analog_input in fem["analog_inputs"].values():
+                            analog_input.setdefault("offset", 0.0)
+
         if "analog_outputs" in controller_cfg:
             for analog_output in controller_cfg["analog_outputs"].values():
                 analog_output.setdefault("offset", 0.0)

--- a/tests/config/test_config_final_actions.py
+++ b/tests/config/test_config_final_actions.py
@@ -1,0 +1,139 @@
+from quam.utils.config import generate_config_final_actions
+
+
+def test_config_no_overwrite_existing_offset():
+    cfg = {
+        "controllers": {
+            "con1": {
+                "analog_outputs": {1: {"offset": 0.5}},
+                "analog_inputs": {2: {"offset": 0.5}},
+            },
+        },
+    }
+
+    generate_config_final_actions(cfg)
+
+    assert cfg == {
+        "controllers": {
+            "con1": {
+                "analog_outputs": {1: {"offset": 0.5}},
+                "analog_inputs": {2: {"offset": 0.5}},
+            },
+        },
+    }
+
+
+def test_config_default_offset():
+    cfg = {
+        "controllers": {
+            "con1": {
+                "analog_outputs": {1: {}},
+                "analog_inputs": {2: {}},
+            },
+        },
+    }
+
+    generate_config_final_actions(cfg)
+
+    assert cfg == {
+        "controllers": {
+            "con1": {
+                "analog_outputs": {1: {"offset": 0.0}},
+                "analog_inputs": {2: {"offset": 0.0}},
+            },
+        },
+    }
+
+
+def test_config_default_offset_LF_FEM():
+    cfg = {
+        "controllers": {
+            "con1": {
+                "fems": {
+                    2: {
+                        "type": "LF",
+                        "analog_outputs": {1: {}},
+                        "analog_inputs": {2: {}},
+                    },
+                },
+            },
+        },
+    }
+
+    generate_config_final_actions(cfg)
+
+    assert cfg == {
+        "controllers": {
+            "con1": {
+                "fems": {
+                    2: {
+                        "type": "LF",
+                        "analog_outputs": {1: {"offset": 0.0}},
+                        "analog_inputs": {2: {"offset": 0.0}},
+                    },
+                },
+            },
+        },
+    }
+
+
+def test_config_no_overwrite_existing_offset_LF_FEM():
+    cfg = {
+        "controllers": {
+            "con1": {
+                "fems": {
+                    2: {
+                        "type": "LF",
+                        "analog_outputs": {1: {"offset": 0.5}},
+                        "analog_inputs": {2: {"offset": 0.5}},
+                    },
+                },
+            },
+        },
+    }
+
+    generate_config_final_actions(cfg)
+
+    assert cfg == {
+        "controllers": {
+            "con1": {
+                "fems": {
+                    2: {
+                        "type": "LF",
+                        "analog_outputs": {1: {"offset": 0.5}},
+                        "analog_inputs": {2: {"offset": 0.5}},
+                    },
+                },
+            },
+        },
+    }
+
+
+def test_config_default_offset_no_outputs_inputs_entries():
+    cfg = {"controllers": {"con1": {}}}
+
+    generate_config_final_actions(cfg)
+
+    assert cfg == {"controllers": {"con1": {}}}
+
+
+def test_config_default_offset_no_outputs_inputs():
+    cfg = {
+        "controllers": {
+            "con1": {
+                "analog_outputs": {},
+                "analog_inputs": {},
+            }
+        }
+    }
+
+    generate_config_final_actions(cfg)
+
+    assert cfg == {
+        "controllers": {
+            "con1": {
+                "analog_outputs": {},
+                "analog_inputs": {},
+            }
+        }
+    }


### PR DESCRIPTION
Analog output ports require an "offset" field by default (this will change in the future).

But for now, this was only supported for OPX+. Here I have added support for the LF-FEM of the OPX1000. 

It isn't needed for the MW-FEM, because the MW-FEM doesn't have any DC components.