### PR TITLE
Fix/Add all MW channel properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Changed
 - Added ports for different hardware. As a consequence we now also support the LF-FEM and MW-FEM
+- `Channel` is now an abstract base class.
+- Moved `intermediate_frequency` to `Channel` from `SingleChannel/IQChannel`.
 
 
 ## [0.3.4]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 ### Added
 - Added `DragCosinePulse`.
 - Added support for sticky channels through the `StickyChannelAddon` (see documentation)
+- Added `Channel.thread`, which defaults to None
 
 ### Changed
 - Added ports for different hardware. As a consequence we now also support the LF-FEM and MW-FEM
 - `Channel` is now an abstract base class.
 - Moved `intermediate_frequency` to `Channel` from `SingleChannel/IQChannel`.
+  The default is `None`. A consequence of this is that `SingleChannel` no longer adds
+    `intermediate_frequency` to the config if it's not set.
 
 
 ## [0.3.4]

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -1087,6 +1087,17 @@ class IQChannel(Channel):
 
 @quam_dataclass
 class _InComplexChannel(Channel, ABC):
+    """A specialized channel class for performing complex demodulation measurements.
+
+    This class extends the basic `Channel` class and provides functionality
+    for performing full dual demodulation measurements on a channel. It allows
+    for the measurement of both in-phase (I) and quadrature (Q) components of
+    a signal, which are essential for characterizing quantum signals.
+
+    This class is used for both input IQ channels on low-frequency analog inputs and for
+    MW inputs in the MW FEM.
+    """
+
     def measure(
         self,
         pulse_name: str,

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -224,6 +224,7 @@ class Channel(QuamComponent, ABC):
     sticky: Optional[StickyChannelAddon] = None
 
     intermediate_frequency: Optional[float] = None
+    thread: Optional[str] = None
 
     @property
     def name(self) -> str:
@@ -512,6 +513,9 @@ class Channel(QuamComponent, ABC):
 
         if self.intermediate_frequency is not None:
             element_config["intermediate_frequency"] = self.intermediate_frequency
+
+        if self.thread is not None:
+            element_config["thread"] = self.thread
 
         self._config_add_digital_outputs(config)
 

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -1578,17 +1578,12 @@ class MWChannel(Channel):
     opx_output: MWFEMAnalogOutputPort
     upconverter: int = 1
 
-    time_of_flight: int = 24
-    smearing: int = 0
-
     def apply_to_config(self, config: Dict) -> None:
         super().apply_to_config(config)
 
         element_config = config["elements"][self.name]
         element_config["MWInput"] = self.opx_output.port_tuple
         element_config["upconverter"] = self.upconverter
-        element_config["smearing"] = self.smearing
-        element_config["time_of_flight"] = self.time_of_flight
 
 
 @quam_dataclass
@@ -1608,11 +1603,16 @@ class InMWChannel(Channel):
 
     opx_input: MWFEMAnalogInputPort
 
+    time_of_flight: int = 24
+    smearing: int = 0
+
     def apply_to_config(self, config: Dict) -> None:
         super().apply_to_config(config)
 
         element_config = config["elements"][self.name]
         element_config["MWOutput"] = self.opx_input.port_tuple
+        element_config["smearing"] = self.smearing
+        element_config["time_of_flight"] = self.time_of_flight
 
 
 @quam_dataclass

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -1089,24 +1089,25 @@ class IQChannel(Channel):
 class InIQChannel(Channel):
     """QuAM component for an IQ input channel
 
-    operations (Dict[str, Pulse]): A dictionary of pulses to be played on this
-        channel. The key is the pulse label (e.g. "readout") and value is a
-        ReadoutPulse.
-    id (str, int): The id of the channel, used to generate the name.
-        Can be a string, or an integer in which case it will add
-        `Channel._default_label`.
-    opx_input_I (Tuple[str, int]): Channel I input port from the OPX perspective,
-        a tuple of (controller_name, port).
-    opx_input_Q (Tuple[str, int]): Channel Q input port from the OPX perspective,
-        a tuple of (controller_name, port).
-    opx_input_offset_I float: The offset of the I channel. Default is 0.
-    opx_input_offset_Q float: The offset of the Q channel. Default is 0.
-    frequency_converter_down (Optional[FrequencyConverter]): Frequency converter
-        QuAM component for the IQ input port. Only needed for the old Octave.
-    time_of_flight (int): Round-trip signal duration in nanoseconds.
-    smearing (int): Additional window of ADC integration in nanoseconds.
-        Used to account for signal smearing.
-    input_gain (float): The gain of the input channel. Default is None.
+    Args:
+        operations (Dict[str, Pulse]): A dictionary of pulses to be played on this
+            channel. The key is the pulse label (e.g. "readout") and value is a
+            ReadoutPulse.
+        id (str, int): The id of the channel, used to generate the name.
+            Can be a string, or an integer in which case it will add
+            `Channel._default_label`.
+        opx_input_I (Tuple[str, int]): Channel I input port from the OPX perspective,
+            a tuple of (controller_name, port).
+        opx_input_Q (Tuple[str, int]): Channel Q input port from the OPX perspective,
+            a tuple of (controller_name, port).
+        opx_input_offset_I float: The offset of the I channel. Default is 0.
+        opx_input_offset_Q float: The offset of the Q channel. Default is 0.
+        frequency_converter_down (Optional[FrequencyConverter]): Frequency converter
+            QuAM component for the IQ input port. Only needed for the old Octave.
+        time_of_flight (int): Round-trip signal duration in nanoseconds.
+        smearing (int): Additional window of ADC integration in nanoseconds.
+            Used to account for signal smearing.
+        input_gain (float): The gain of the input channel. Default is None.
     """
 
     opx_input_I: Union[Tuple[str, int], Tuple[str, int, int], LFAnalogInputPort]
@@ -1557,6 +1558,23 @@ class InIQOutSingleChannel(SingleChannel, InIQChannel):
 
 @quam_dataclass
 class MWChannel(Channel):
+    """QuAM component for a MW FEM output channel
+
+    Args:
+        operations (Dict[str, Pulse]): A dictionary of pulses to be played on this
+            channel. The key is the pulse label (e.g. "X90") and value is a Pulse.
+        id (str, int): The id of the channel, used to generate the name.
+            Can be a string, or an integer in which case it will add
+            `Channel._default_label`.
+        opx_output (MWFEMAnalogOutputPort): Channel output port from the OPX perspective.
+        intermediate_frequency (float): Intermediate frequency of OPX output, default
+            is None.
+        upconverter (int): The upconverter to use. Default is 1.
+        time_of_flight (int): Round-trip signal duration in nanoseconds.
+        smearing (int): Additional window of ADC integration in nanoseconds.
+            Used to account for signal smearing.
+    """
+
     opx_output: MWFEMAnalogOutputPort
     upconverter: int = 1
 
@@ -1575,6 +1593,19 @@ class MWChannel(Channel):
 
 @quam_dataclass
 class InMWChannel(Channel):
+    """QuAM component for a MW FEM input channel
+
+    Args:
+        operations (Dict[str, Pulse]): A dictionary of pulses to be played on this
+            channel. The key is the pulse label (e.g. "X90") and value is a Pulse.
+        id (str, int): The id of the channel, used to generate the name.
+            Can be a string, or an integer in which case it will add
+            `Channel._default_label`.
+        opx_input (MWFEMAnalogInputPort)): Channel input port from the OPX perspective.
+        intermediate_frequency (float): Intermediate frequency of OPX output, default
+            is None.
+    """
+
     opx_input: MWFEMAnalogInputPort
 
     def apply_to_config(self, config: Dict) -> None:
@@ -1586,4 +1617,22 @@ class InMWChannel(Channel):
 
 @quam_dataclass
 class InOutMWChannel(MWChannel, InMWChannel):
+    """QuAM component for a MW FEM input channel
+
+    Args:
+        operations (Dict[str, Pulse]): A dictionary of pulses to be played on this
+            channel. The key is the pulse label (e.g. "X90") and value is a Pulse.
+        id (str, int): The id of the channel, used to generate the name.
+            Can be a string, or an integer in which case it will add
+            `Channel._default_label`.
+        opx_output (MWFEMAnalogOutputPort): Channel output port from the OPX perspective.
+        opx_input (MWFEMAnalogInputPort)): Channel input port from the OPX perspective.
+        intermediate_frequency (float): Intermediate frequency of OPX output, default
+            is None.
+        upconverter (int): The upconverter to use. Default is 1.
+        time_of_flight (int): Round-trip signal duration in nanoseconds.
+        smearing (int): Additional window of ADC integration in nanoseconds.
+            Used to account for signal smearing.
+    """
+
     pass

--- a/quam/components/pulses.py
+++ b/quam/components/pulses.py
@@ -182,10 +182,11 @@ class Pulse(QuamComponent):
 
         Raises:
             ValueError: If the waveform type (single or IQ) does not match the parent
-                channel type (SingleChannel, IQChannel, InOutIQChannel).
+                channel type (SingleChannel, IQChannel, InOutIQChannel, MWChannel,
+                InOutMWChannel).
         """
 
-        from quam.components.channels import SingleChannel, IQChannel
+        from quam.components.channels import SingleChannel, IQChannel, MWChannel
 
         pulse_config = config["pulses"][self.pulse_name]
 
@@ -199,7 +200,7 @@ class Pulse(QuamComponent):
             wf_type = "constant"
             if isinstance(waveform, complex):
                 waveforms = {"I": waveform.real, "Q": waveform.imag}
-            elif isinstance(self.channel, IQChannel):
+            elif isinstance(self.channel, (IQChannel, MWChannel)):
                 waveforms = {"I": waveform, "Q": 0.0}
             else:
                 waveforms = {"single": waveform}
@@ -208,7 +209,7 @@ class Pulse(QuamComponent):
             wf_type = "arbitrary"
             if np.iscomplexobj(waveform):
                 waveforms = {"I": list(waveform.real), "Q": list(waveform.imag)}
-            elif isinstance(self.channel, IQChannel):
+            elif isinstance(self.channel, (IQChannel, MWChannel)):
                 waveforms = {"I": waveform, "Q": np.zeros_like(waveform)}
             else:
                 waveforms = {"single": list(waveform)}
@@ -218,10 +219,10 @@ class Pulse(QuamComponent):
         # Add check that waveform type (single or IQ) matches parent
         if "single" in waveforms and not isinstance(self.channel, SingleChannel):
             raise ValueError(
-                "Waveform type 'single' not allowed for IQChannel"
+                "Waveform type 'single' not allowed for (IQChannel, MWChannel)"
                 f" '{self.channel.name}'"
             )
-        elif "I" in waveforms and not isinstance(self.channel, IQChannel):
+        elif "I" in waveforms and not isinstance(self.channel, (IQChannel, MWChannel)):
             raise ValueError(
                 "Waveform type 'IQ' not allowed for SingleChannel"
                 f" '{self.channel.name}'"

--- a/tests/components/channels/test_IQ_channel.py
+++ b/tests/components/channels/test_IQ_channel.py
@@ -35,7 +35,7 @@ def test_IQ_channel_inferred_RF_frequency():
         frequency_converter_up=None,
     )
 
-    assert channel.intermediate_frequency == 0.0
+    assert channel.intermediate_frequency is None
     assert channel.LO_frequency == "#./frequency_converter_up/LO_frequency"
     assert channel.RF_frequency == "#./inferred_RF_frequency"
     with pytest.raises(AttributeError):
@@ -112,7 +112,6 @@ def test_generate_config(qua_config):
 
     assert qua_config["elements"] == {
         "out_channel": {
-            "intermediate_frequency": 0.0,
             "mixInputs": {
                 "I": ("con1", 1),
                 "Q": ("con1", 2),
@@ -145,7 +144,6 @@ def test_generate_config_ports(qua_config):
 
     assert qua_config["elements"] == {
         "out_channel": {
-            "intermediate_frequency": 0.0,
             "mixInputs": {
                 "I": ("con1", 1),
                 "Q": ("con1", 2),

--- a/tests/components/channels/test_in_IQ_out_single_channel.py
+++ b/tests/components/channels/test_in_IQ_out_single_channel.py
@@ -26,6 +26,7 @@ def test_in_single_channel_attr_annotations():
         "opx_input_offset_I",
         "opx_input_offset_Q",
         "frequency_converter_down",
+        "thread",
     }
 
 

--- a/tests/components/channels/test_in_single_channel.py
+++ b/tests/components/channels/test_in_single_channel.py
@@ -7,6 +7,7 @@ def test_in_single_channel_attr_annotations():
     attr_annotations = get_dataclass_attr_annotations(InSingleChannel)
     assert set(attr_annotations["required"]) == {"opx_input"}
     assert set(attr_annotations["optional"]) == {
+        "intermediate_frequency",
         "operations",
         "sticky",
         "id",
@@ -14,6 +15,7 @@ def test_in_single_channel_attr_annotations():
         "opx_input_offset",
         "time_of_flight",
         "smearing",
+        "thread",
     }
 
 

--- a/tests/components/channels/test_in_single_out_IQ_channel.py
+++ b/tests/components/channels/test_in_single_out_IQ_channel.py
@@ -25,6 +25,7 @@ def test_in_single_channel_attr_annotations():
         "opx_input_offset",
         "time_of_flight",
         "smearing",
+        "thread"
     }
 
 
@@ -85,7 +86,7 @@ def test_generate_config(qua_config):
             "analog_inputs": {
                 1: {"gain_db": 0, "shareable": False},
             },
-            "analog_outputs": {
+            "analog_outputs": {     
                 1: {"delay": 0, "shareable": False},
                 2: {"delay": 0, "shareable": False},
             },
@@ -94,7 +95,6 @@ def test_generate_config(qua_config):
 
     assert qua_config["elements"] == {
         "in_out_channel": {
-            "intermediate_frequency": 0.0,
             "mixInputs": {
                 "I": ("con1", 1),
                 "Q": ("con1", 2),

--- a/tests/components/test_octave.py
+++ b/tests/components/test_octave.py
@@ -280,7 +280,6 @@ def test_channel_add_RF_outputs(octave, qua_config):
 
     expected_cfg_elements = {
         "ch": {
-            "intermediate_frequency": 0.0,
             "RF_inputs": {"port": ("octave1", 2)},
             "operations": {},
         }
@@ -308,7 +307,6 @@ def test_channel_add_RF_inputs(octave, qua_config):
 
     expected_cfg_elements = {
         "ch": {
-            "intermediate_frequency": 0.0,
             "RF_inputs": {"port": ("octave1", 3)},
             "RF_outputs": {"port": ("octave1", 4)},
             "operations": {},


### PR DESCRIPTION
This PR adds the following changes
- Add missing attributes to `MWChannel`
- Make `Channel` an abstract base class
- Move `intermediate_frequency` to `Channel`, meaning that all channels share this property
- Add `smearing`, `time_of_flight`