### PR TITLE
Fix: Remove upsampling mode for LFFEMAnalogOutputPort

### DIFF
--- a/quam/components/ports/analog_outputs.py
+++ b/quam/components/ports/analog_outputs.py
@@ -56,7 +56,8 @@ class LFFEMAnalogOutputPort(LFAnalogOutputPort, FEMPort):
     def get_port_properties(self) -> Dict[str, Any]:
         port_properties = super().get_port_properties()
         port_properties["sampling_rate"] = self.sampling_rate
-        port_properties["upsampling_mode"] = self.upsampling_mode
+        if self.sampling_rate == 1e9:
+            port_properties["upsampling_mode"] = self.upsampling_mode
         port_properties["output_mode"] = self.output_mode
         return port_properties
 

--- a/tests/components/ports/test_lf_fem_analog_ports.py
+++ b/tests/components/ports/test_lf_fem_analog_ports.py
@@ -72,6 +72,16 @@ def test_lf_fem_analog_output_port():
         "offset": 0.1,
     }
 
+    port.sampling_rate = 2e9
+
+    assert port.get_port_properties() == {
+        "delay": 0,
+        "shareable": False,
+        "output_mode": "direct",
+        "sampling_rate": 2e9,
+        "offset": 0.1,
+    }
+
 
 def test_lf_fem_analog_input_port():
     with pytest.raises(TypeError):


### PR DESCRIPTION
This only happens when `port.sampling_rate != 1e9`. Otherwise an error is raised during config validation