### PR TITLE
Feat: Add time tagging to channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+### Added
+- Added time tagging to channels
+
+
 ## [0.3.7]
 ### Added
 - Added `WaveformPulse` to allow for pre-defined waveforms.

--- a/docs/components/channels.md
+++ b/docs/components/channels.md
@@ -261,3 +261,5 @@ Two QUA variables are returned:
 - `times` is a QUA array containing the times of arrival of the signal.
   It will contain at most `size` entries, though it may contain fewer if the maximum duration is reached first.
 - `counts` is a QUA integer containing the number of measured events, being at most equal to `size`.
+
+Additional information on time tagging can be found in the [Time Tagging QUA documentation](https://docs.quantum-machines.co/latest/docs/Guides/features/#time-tagging).

--- a/docs/components/channels.md
+++ b/docs/components/channels.md
@@ -214,6 +214,7 @@ This can be done by directly using the base [pulses.Pulse][quam.components.pulse
 channel.operations["digital"] = pulses.Pulse(length=100, digital_marker=[(1, 20, 0, 10)])
 ```
 
+
 ## Sticky channels
 A channel can be set to be sticky, meaning that the voltage after a pulse will remain at the last value of the pulse.
 Details can be found in the [Sticky channel QUA documentation](https://docs.quantum-machines.co/latest/docs/Guides/features/#sticky-element).
@@ -223,3 +224,40 @@ from quam.components.channels import StickyChannelAddon
 
 channel.sticky = StickyChannelAddon(duration=...)
 ```
+
+
+## Time Tagging
+Time tagging is a feature that allows for the measurement of the time of arrival of a signal.
+It is implemented as the [TimeTaggingAddon][quam.components.channels.TimeTaggingAddon] to the [InSingleChannel][quam.components.channels.InSingleChannel].
+
+To use the time tagging feature, the [TimeTaggingAddon][quam.components.channels.TimeTaggingAddon] must be added to the [InSingleChannel][quam.components.channels.InSingleChannel]:
+```python
+from quam.components.channels import InSingleChannel, TimeTaggingAddon
+
+channel = InSingleChannel(
+    id="channel",
+    opx_input=("con1", 1),
+    time_tagging=TimeTaggingAddon(
+        signal_threshold=0.195,  # in units of V
+        signal_polarity="below",
+        derivative_threshold=0.073,  # in units of V/ns
+        derivative_polarity="below",
+    )
+)
+```
+All parameters are optional, and are by default set to the values shown above.
+
+Once the time tagging addon is added, the [InSingleChannel.measure_time_tagging()][quam.components.channels.InSingleChannel.measure_time_tagging] method can be used within a QUA program to measure the time of arrival of the signal:
+```python
+times, counts = channel.measure_time_tagging(size=1000, max_duration=3000)
+```
+
+- The `size` parameter specifies the maximum number of samples to collect.
+- The `max_duration` parameter specifies the maximum duration to collect samples for.
+
+
+Two QUA variables are returned: 
+
+- `times` is a QUA array containing the times of arrival of the signal.
+  It will contain at most `size` entries, though it may contain fewer if the maximum duration is reached first.
+- `counts` is a QUA integer containing the number of measured events, being at most equal to `size`.

--- a/docs/components/pulses.md
+++ b/docs/components/pulses.md
@@ -8,14 +8,14 @@ All pulses in QuAM are instances of the [Pulse][quam.components.pulses.Pulse] cl
 
 - **[SquarePulse][quam.components.pulses.SquarePulse]**: Typically used for simple quantum operations like flips or resets, characterized by a constant amplitude throughout its duration.
 - **[GaussianPulse][quam.components.pulses.GaussianPulse]**: Ideal for minimizing spectral leakage due to its smooth rise and fall, commonly used in operations requiring high fidelity.
-- **[DragPulse][quam.components.pulses.DragPulse]**: Designed to correct phase errors in quantum gates, enhancing the accuracy of operations involving superconducting qubits.
+- **[DragGaussianPulse][quam.components.pulses.DragGaussianPulse]**: Designed to correct phase errors in quantum gates, enhancing the accuracy of operations involving superconducting qubits.
 
 The full list of predefined pulses can be found in the [pulses][quam.components.pulses] module.
 Users can also define custom pulses by subclassing the `Pulse` class. This flexibility allows the creation of tailored waveforms that suit specific experimental requirements.
 
 All pulses in QuAM are instances of the [Pulse][quam.components.pulses.Pulse] class.
 The QuAM library contains a set of common pulse types in the [pulses][quam.components.pulses] module.
-Typical examples are [SquarePulse][quam.components.pulses.SquarePulse], [GaussianPulse][quam.components.pulses.GaussianPulse], and [DragPulse][quam.components.pulses.DragPulse].
+Typical examples are [SquarePulse][quam.components.pulses.SquarePulse], [GaussianPulse][quam.components.pulses.GaussianPulse], and [DragGaussianPulse][quam.components.pulses.DragGaussianPulse].
 Users can supplement these common pulses with their own custom pulses by subclassing the [Pulse][quam.components.pulses.Pulse] class (see [Custom QuAM Components](/components/custom-components) for details). 
 
 

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -279,7 +279,6 @@ class Channel(QuamComponent, ABC):
 
     digital_outputs: Dict[str, DigitalOutputChannel] = field(default_factory=dict)
     sticky: Optional[StickyChannelAddon] = None
-    time_tagging: Optional[TimeTaggingAddon] = None
     intermediate_frequency: Optional[float] = None
     thread: Optional[str] = None
 
@@ -687,6 +686,8 @@ class InSingleChannel(Channel):
 
     time_of_flight: int = 24
     smearing: int = 0
+
+    time_tagging: Optional[TimeTaggingAddon] = None
 
     def apply_to_config(self, config: dict):
         """Adds this InSingleChannel to the QUA configuration.

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -984,7 +984,7 @@ class InSingleChannel(Channel):
             raise ValueError(f"Invalid time tagging mode: {mode}")
 
         if qua_vars is None:
-            times = declare(fixed, size=size)
+            times = declare(int, size=size)
             counts = declare(int)
         else:
             times, counts = qua_vars

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -207,7 +207,7 @@ class TimeTaggingAddon(QuamComponent):
     Args:
         signal_threshold (float, optional): The signal threshold in volts.
             If not specified, the default value is 800 / 4096 ≈ 0.195 V.
-        signal_polarity (Literal["above", "below"]): The polarity of the signal 
+        signal_polarity (Literal["above", "below"]): The polarity of the signal
             threshold. Default is "below".
         derivative_threshold (float, optional): The derivative threshold in volts/ns.
             If not specified, the default value is 300 / 4096 ≈ 0.073 V/ns.
@@ -217,9 +217,9 @@ class TimeTaggingAddon(QuamComponent):
     For details see [Time Tagging](https://docs.quantum-machines.co/latest/docs/Guides/features/#time-tagging)
     """
 
-    signal_threshold: Optional[float] = None
+    signal_threshold: float = 800 / 4096
     signal_polarity: Literal["above", "below"] = "below"
-    derivative_threshold: Optional[float] = None
+    derivative_threshold: float = 300 / 4096
     derivative_polarity: Literal["above", "below"] = "below"
     enabled: bool = True
 
@@ -249,18 +249,11 @@ class TimeTaggingAddon(QuamComponent):
 
         ch_cfg = config["elements"][self.channel.name]
         ch_cfg["outputPulseParameters"] = {
+            "signalThreshold": int(self.signal_threshold * 4096),
             "signalPolarity": self.signal_polarity,
+            "derivativeThreshold": int(self.derivative_threshold * 4096),
             "derivativePolarity": self.derivative_polarity,
         }
-
-        if self.signal_threshold is not None:
-            # TODO Replace with units.volts2raw() when it's added
-            threshold_raw_units = int(self.signal_threshold * 4096)
-            ch_cfg["outputPulseParameters"]["signalThreshold"] = threshold_raw_units
-
-        if self.derivative_threshold is not None:
-            threshold_raw_units = int(self.derivative_threshold * 4096)
-            ch_cfg["outputPulseParameters"]["derivativeThreshold"] = threshold_raw_units
 
 
 @quam_dataclass
@@ -948,7 +941,7 @@ class InSingleChannel(Channel):
         pulse_name: str,
         size: int,
         max_time: QuaNumberType,
-        qua_vars: Optional[Tuple[QuaVariableType, QuaNumberType] = None,
+        qua_vars: Optional[Tuple[QuaVariableType, QuaNumberType]] = None,
         stream: Optional[StreamType] = None,
         mode: Literal["analog", "high_res", "digital"] = "analog",
     ) -> Tuple[QuaVariableType, QuaNumberType]:

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -201,6 +201,7 @@ class StickyChannelAddon(QuamComponent):
         }
 
 
+@quam_dataclass
 class TimeTaggingAddon(QuamComponent):
     """Addon to perform time tagging on a channel.
 

--- a/tests/components/channels/test_in_single_channel.py
+++ b/tests/components/channels/test_in_single_channel.py
@@ -16,6 +16,7 @@ def test_in_single_channel_attr_annotations():
         "time_of_flight",
         "smearing",
         "thread",
+        "time_tagging",
     }
 
 

--- a/tests/components/channels/test_in_single_out_IQ_channel.py
+++ b/tests/components/channels/test_in_single_out_IQ_channel.py
@@ -25,7 +25,8 @@ def test_in_single_channel_attr_annotations():
         "opx_input_offset",
         "time_of_flight",
         "smearing",
-        "thread"
+        "thread",
+        "time_tagging",
     }
 
 

--- a/tests/components/channels/test_time_tagging.py
+++ b/tests/components/channels/test_time_tagging.py
@@ -1,14 +1,14 @@
-from quam.components.channels import SingleChannel, TimeTaggingAddon
+from quam.components.channels import InSingleChannel, TimeTaggingAddon
 from quam.core.quam_classes import QuamRoot, quam_dataclass
 
 
 @quam_dataclass
 class SingleChannelQuAM(QuamRoot):
-    channel: SingleChannel
+    channel: InSingleChannel
 
 
 def test_time_tagging_cfg():
-    channel = SingleChannel(id="channel", opx_output=("con1", 1))
+    channel = InSingleChannel(id="channel", opx_input=("con1", 1))
     channel.time_tagging = TimeTaggingAddon()
 
     machine = SingleChannelQuAM(channel=channel)
@@ -24,7 +24,7 @@ def test_time_tagging_cfg():
 
 
 def test_time_tagging_cfg_disabled():
-    channel = SingleChannel(id="channel", opx_output=("con1", 1))
+    channel = InSingleChannel(id="channel", opx_input=("con1", 1))
     channel.time_tagging = TimeTaggingAddon(enabled=False)
 
     machine = SingleChannelQuAM(channel=channel)
@@ -33,7 +33,7 @@ def test_time_tagging_cfg_disabled():
 
 
 def test_time_tagging_cfg_custom_thresholds():
-    channel = SingleChannel(id="channel", opx_output=("con1", 1))
+    channel = InSingleChannel(id="channel", opx_input=("con1", 1))
     channel.time_tagging = TimeTaggingAddon(
         signal_threshold=0.2, derivative_threshold=0.1
     )

--- a/tests/components/channels/test_time_tagging.py
+++ b/tests/components/channels/test_time_tagging.py
@@ -1,0 +1,49 @@
+from quam.components.channels import SingleChannel, TimeTaggingAddon
+from quam.core.quam_classes import QuamRoot, quam_dataclass
+
+
+@quam_dataclass
+class SingleChannelQuAM(QuamRoot):
+    channel: SingleChannel
+
+
+def test_time_tagging_cfg():
+    channel = SingleChannel(id="channel", opx_output=("con1", 1))
+    channel.time_tagging = TimeTaggingAddon()
+
+    machine = SingleChannelQuAM(channel=channel)
+    cfg = machine.generate_config()
+
+    assert "outputPulseParameters" in cfg["elements"]["channel"]
+    assert cfg["elements"]["channel"]["outputPulseParameters"] == {
+        "signalThreshold": 800,
+        "signalPolarity": "below",
+        "derivativeThreshold": 300,
+        "derivativePolarity": "below",
+    }
+
+
+def test_time_tagging_cfg_disabled():
+    channel = SingleChannel(id="channel", opx_output=("con1", 1))
+    channel.time_tagging = TimeTaggingAddon(enabled=False)
+
+    machine = SingleChannelQuAM(channel=channel)
+    cfg = machine.generate_config()
+    assert "outputPulseParameters" not in cfg["elements"]["channel"]
+
+
+def test_time_tagging_cfg_custom_thresholds():
+    channel = SingleChannel(id="channel", opx_output=("con1", 1))
+    channel.time_tagging = TimeTaggingAddon(
+        signal_threshold=0.2, derivative_threshold=0.1
+    )
+
+    machine = SingleChannelQuAM(channel=channel)
+    cfg = machine.generate_config()
+    assert "outputPulseParameters" in cfg["elements"]["channel"]
+    assert cfg["elements"]["channel"]["outputPulseParameters"] == {
+        "signalThreshold": int(0.2 * 4096),
+        "signalPolarity": "below",
+        "derivativeThreshold": int(0.1 * 4096),
+        "derivativePolarity": "below",
+    }


### PR DESCRIPTION
Time tagging can be performed as follows:

**Step 1: Add `TimeTaggingAddon` to channel**
```python
channel.time_tagging = TimeTaggingAddon(signal_threshold=0.2, ...)
```

**Step 2: Perform time tagging**
```python
times, counts = channel.measure_time_tagging("readout", size=1000, max_time=800)
```

## Remaining tasks
- [x] Change units from DAC to V
- [x] Add documentation
- [x] Add docstrings
- [x] Add tests
- [x] Allow qua variables to be sent