### PR TITLE
Feat: Add default integration weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Changed
+- `Pulse.integration_weights` now defaults to `#./default_integration_weights`, which returns [(1, pulse.length)]
+
 ## [0.3.8]
 ### Added
 - Added time tagging to channels

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -160,7 +160,7 @@ class StickyChannelAddon(QuamComponent):
     """Addon to make channels sticky.
 
     Args:
-        duration (int): The ramp to zero duration, in ns.
+        duration (int): The w to zero duration, in ns.
         enabled (bool, optional): If False, the sticky parameters are not applied.
             Default is True.
         analog (bool, optional): If False, the sticky parameters are not applied to

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -160,7 +160,7 @@ class StickyChannelAddon(QuamComponent):
     """Addon to make channels sticky.
 
     Args:
-        duration (int): The w to zero duration, in ns.
+        duration (int): The ramp to zero duration, in ns.
         enabled (bool, optional): If False, the sticky parameters are not applied.
             Default is True.
         analog (bool, optional): If False, the sticky parameters are not applied to

--- a/quam/components/pulses.py
+++ b/quam/components/pulses.py
@@ -460,17 +460,21 @@ class ReadoutPulse(BaseReadoutPulse, ABC):
             integration weights in radians.
     """
 
-    integration_weights: Union[List[float], List[Tuple[float, int]]] = None
+    integration_weights: Union[List[float], List[Tuple[float, int]]] = (
+        "#./default_integration_weights"
+    )
     integration_weights_angle: float = 0
+
+    @property
+    def default_integration_weights(self) -> List[Tuple[float, int]]:
+        return [(1, self.length)]
 
     def integration_weights_function(self) -> List[Tuple[Union[complex, float], int]]:
         from qualang_tools.config import convert_integration_weights
 
         phase = np.exp(1j * self.integration_weights_angle)
 
-        if self.integration_weights is None or not len(self.integration_weights):
-            integration_weights = [(1, self.length)]
-        elif isinstance(self.integration_weights[0], float):
+        if isinstance(self.integration_weights[0], float):
             integration_weights = convert_integration_weights(self.integration_weights)
         else:
             integration_weights = self.integration_weights

--- a/tests/components/pulses/test_pulse_weights.py
+++ b/tests/components/pulses/test_pulse_weights.py
@@ -24,20 +24,22 @@ def test_constant_readout_pulse_integration_weights_default():
     compare_integration_weights(expected_weights, weights)
 
 
-def test_empty_integration_weights():
-    for weights in ([], np.array([]), None):
-        pulse = pulses.SquareReadoutPulse(
-            length=100, amplitude=1, integration_weights=weights
-        )
+def test_default_integration_weights():
+    pulse = pulses.SquareReadoutPulse(length=100, amplitude=1)
+    assert pulse.default_integration_weights == [(1, 100)]
 
-        weights = pulse.integration_weights_function()
-        expected_weights = {
-            "real": [(1, 100)],
-            "imag": [(0, 100)],
-            "minus_real": [(-1, 100)],
-            "minus_imag": [(0, 100)],
-        }
-        compare_integration_weights(expected_weights, weights)
+
+def test_empty_integration_weights():
+    pulse = pulses.SquareReadoutPulse(length=100, amplitude=1)
+
+    weights = pulse.integration_weights_function()
+    expected_weights = {
+        "real": [(1, 100)],
+        "imag": [(0, 100)],
+        "minus_real": [(-1, 100)],
+        "minus_imag": [(0, 100)],
+    }
+    compare_integration_weights(expected_weights, weights)
 
 
 def test_constant_readout_pulse_integration_weights_phase_shift():


### PR DESCRIPTION
Adds `ReadoutPulse.default_integration_weights` property that returns `[(1, pulse.length)]`
Fixes #54 