### PR TITLE
Feat: Add `relative_path` to `QuamBase.get_references`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added `QuamBase.set_at_reference` to set a value at a reference
 - Added `string_reference.get_parent_reference` to get the parent reference of a string reference
 - Added `FrequencyConverter.LO_frequency` setter which updates the local oscillator frequency
+- Added optional `relative_path` to method `QuamBase.get_reference()`
 
 ### Changed
 - `Pulse.integration_weights` now defaults to `#./default_integration_weights`, which returns [(1, pulse.length)]

--- a/quam/core/quam_classes.py
+++ b/quam/core/quam_classes.py
@@ -377,6 +377,8 @@ class QuamBase(ReferenceClass):
 
         try:
             base_reference = self.parent.get_reference()
+            if base_reference == "#/":
+                base_reference = "#"
         except AttributeError:
             raise AttributeError(
                 f"Unable to extract reference path for {self}: Could not get "
@@ -669,8 +671,16 @@ class QuamRoot(QuamBase):
         if isinstance(converted_val, QuamBase) and name != "parent":
             converted_val.parent = self
 
-    def get_reference(self):
-        return "#"
+    def get_reference(
+        self, attr: Optional[str] = None, relative_path: Optional[str] = None
+    ) -> Optional[str]:
+        if attr is not None:
+            return f"#/{attr}"
+
+        reference = "#/"
+        if relative_path is not None:
+            reference = string_reference.join_references(reference, relative_path)
+        return reference
 
     def save(
         self,

--- a/quam/utils/string_reference.py
+++ b/quam/utils/string_reference.py
@@ -151,3 +151,85 @@ def split_reference(string: str) -> Tuple[str, str]:
     if parent_reference in ("#", "#.", "#.."):
         parent_reference += "/"
     return parent_reference, attr
+
+
+def join_references(base, relative):
+    """Joins a base reference with another relative reference
+
+    Args:
+        base: The base reference, either absolute ("#/") or relative ("#./" or "#../")
+        relative: The relative reference ("#./" or "#../")
+
+    Returns:
+        The joined reference
+
+    Disallows:
+      - Joining an absolute relative path ('#/...') with any base
+        (raises ValueError).
+      - Navigating above the root of an absolute base (#/...)
+        (raises ValueError).
+
+    Examples:
+        join_references("#/a/b/c", "#./d/e/f") == "#/a/b/c/d/e/f"
+        join_references("#/a/b/c", "#../d/e/f") == "#/a/b/d/e/f"
+    """
+    # Disallow if 'relative' starts with "#/" (i.e., an absolute path)
+    if relative.startswith("#/"):
+        raise ValueError(
+            "Cannot join an absolute reference path with another absolute path"
+            f"base reference: {base}, relative reference: {relative}"
+        )
+
+    # Split the base and relative references into segments (dropping the '#' prefix)
+    base_segments = base[1:].split("/")
+    relative_segments = relative[1:].split("/")
+
+    # Check if the base is absolute: '#/...' => first segment == ""
+    is_absolute = base_segments and base_segments[0] == ""
+
+    # Process each segment from the relative path
+    for seg in relative_segments:
+        if seg == ".":
+            # "current directory": do nothing
+            continue
+        elif seg == "..":
+            _handle_go_up(base_segments, is_absolute)
+        else:
+            # Normal segment: just append
+            base_segments.append(seg)
+
+    # Reassemble and return
+    return "#" + "/".join(base_segments)
+
+
+def _handle_go_up(base_segments, is_absolute):
+    """Handles a ".." (parent directory) segment, modifying base_segments in place.
+
+    - If base is absolute, never allow popping the empty root segment [""].
+    - If base is relative, allow accumulating ".." if there's nowhere left to pop.
+    - Special rule: if the last segment is ".", replace it with ".." (to handle
+      cases like #./a + #../../b => #../b).
+    """
+    if is_absolute:
+        # For an absolute base (e.g. ["", "a", "b"]), we don't let it go above #/
+        # The first segment is always "", so we only pop if len > 1
+        if len(base_segments) > 1:
+            base_segments.pop()
+        else:
+            raise ValueError("Cannot navigate above the root")
+    else:
+        # For a relative base, we can accumulate ".."
+        if not base_segments:
+            # Nothing to pop, just accumulate an additional ".."
+            base_segments.append("..")
+        else:
+            last = base_segments[-1]
+            if last == ".":
+                # Replace '.' with '..'
+                base_segments[-1] = ".."
+            elif last == "..":
+                # Already '..', add one more level
+                base_segments.append("..")
+            else:
+                # Normal directory name, pop it
+                base_segments.pop()

--- a/quam/utils/string_reference.py
+++ b/quam/utils/string_reference.py
@@ -174,16 +174,16 @@ def join_references(base, relative):
     if relative.startswith("#/"):
         raise ValueError("Cannot join an absolute path with another absolute path")
 
-    # 2) Split the base and relative references (dropping the '#' prefix)
-    base_segments = base[1:].split("/")
-    relative_segments = relative[1:].split("/")
+    # Determine if base is absolute (#/...)
+    is_absolute = base.startswith("#/")
 
-    # Determine if base is absolute (#/...) => first segment == ""
-    is_absolute = base_segments and base_segments[0] == ""
+    # 2) Split the base and relative references (dropping the '#' prefix)
+    base_segments = [""] if base == "#/" else base[1:].split("/")
+    relative_segments = relative[1:].split("/")
 
     # 3) Process each segment from the relative path
     for seg in relative_segments:
-        if seg == ".":
+        if seg in [".", ""]:
             # "current directory": do nothing
             continue
         elif seg == "..":
@@ -192,14 +192,14 @@ def join_references(base, relative):
             # Normal segment: just append
             base_segments.append(seg)
 
-    # 4) If base is absolute, remove trailing empty segments (i.e. trailing slash),
-    #    but leave the single empty segment if it's truly the root '#/'.
-    if is_absolute:
-        while len(base_segments) > 1 and base_segments[-1] == "":
-            base_segments.pop()
+    # Remove empty segments
+    base_segments = [seg for seg in base_segments if seg != ""]
 
-    # 5) Reassemble and return
-    return "#" + "/".join(base_segments)
+    # Reassemble and return
+    if is_absolute:
+        return "#/" + "/".join(base_segments)
+    else:
+        return "#" + "/".join(base_segments)
 
 
 def _handle_go_up(base_segments, is_absolute):

--- a/tests/quam_base/referencing/test_get_reference_relative_path.py
+++ b/tests/quam_base/referencing/test_get_reference_relative_path.py
@@ -1,0 +1,104 @@
+from typing import List, Optional
+
+import pytest
+
+from quam.core import *
+
+
+@quam_dataclass
+class QuamComponentTest(QuamComponent):
+    test_str: str
+    inner_child: Optional["QuamComponentTest"] = None
+
+
+@quam_dataclass
+class QuamRootTest(QuamRoot):
+    quam_elem: QuamComponentTest
+    quam_elem_list: List[QuamComponentTest]
+
+
+@pytest.fixture
+def setup_quam_hierarchy():
+    nested_child = QuamComponentTest(test_str="hi1")
+    child_component = QuamComponentTest(test_str="hi1", inner_child=nested_child)
+
+    child_without_parent = QuamComponentTest(test_str="hi2")
+
+    list_child = QuamComponentTest(test_str="hi3")
+
+    root = QuamRootTest(quam_elem=child_component, quam_elem_list=[list_child])
+
+    return root, child_component, nested_child, child_without_parent, list_child
+
+
+@pytest.mark.usefixtures("setup_quam_hierarchy")
+def test_get_reference_with_attr(setup_quam_hierarchy):
+    root, child_component, nested_child, _, _ = setup_quam_hierarchy
+
+    # Test getting reference with attr
+    assert (
+        child_component.get_reference(attr="inner_child") == "#/quam_elem/inner_child"
+    )
+
+
+def test_get_reference_with_relative_path(setup_quam_hierarchy):
+    root, child_component, nested_child, _, _ = setup_quam_hierarchy
+
+    # Test getting reference with relative_path
+    assert (
+        child_component.get_reference(relative_path="#./inner_child")
+        == "#/quam_elem/inner_child"
+    )
+
+
+def test_get_reference_with_both_attr_and_relative_path(setup_quam_hierarchy):
+    root, child_component, nested_child, _, _ = setup_quam_hierarchy
+
+    # Test that providing both attr and relative_path raises a ValueError
+    with pytest.raises(ValueError):
+        child_component.get_reference(
+            attr="inner_child", relative_path="#./inner_child"
+        )
+
+
+def test_get_reference_with_invalid_relative_path(setup_quam_hierarchy):
+    root, child_component, nested_child, _, _ = setup_quam_hierarchy
+
+    # Test that providing an invalid relative_path raises a ValueError
+    with pytest.raises(ValueError):
+        child_component.get_reference(relative_path="not_a_reference")
+
+
+def test_get_reference_without_parent():
+    # Create a component without a parent
+    orphan_component = QuamComponentTest(test_str="orphan")
+
+    # Test that trying to get a reference without a parent raises an AttributeError
+    with pytest.raises(AttributeError):
+        orphan_component.get_reference(attr="test_str")
+
+
+def test_get_reference_with_parent_operator(setup_quam_hierarchy):
+    root, child_component, nested_child, _, _ = setup_quam_hierarchy
+
+    # Test getting reference with parent operator
+    assert nested_child.get_reference(relative_path="#../") == "#/quam_elem"
+
+
+def test_get_reference_with_multiple_parent_operators(setup_quam_hierarchy):
+    root, child_component, nested_child, _, _ = setup_quam_hierarchy
+
+    # Test getting reference with multiple parent operators
+    assert (
+        nested_child.get_reference(relative_path="#../../quam_elem_list/0")
+        == "#/quam_elem_list/0"
+    )
+
+
+def test_get_reference_with_complex_relative_path(setup_quam_hierarchy):
+    root, child_component, nested_child, _, _ = setup_quam_hierarchy
+
+    # Test getting reference with a complex relative path
+    assert (
+        nested_child.get_reference(relative_path="#../inner_child/../") == "#/quam_elem"
+    )

--- a/tests/quam_base/referencing/test_reference_path.py
+++ b/tests/quam_base/referencing/test_reference_path.py
@@ -9,7 +9,7 @@ def test_root_reference(BareQuamRoot):
     root = BareQuamRoot()
     assert root._root is root
 
-    assert root.get_reference() == "#"
+    assert root.get_reference() == "#/"
 
 
 @quam_dataclass
@@ -32,7 +32,7 @@ def test_quam_component_no_parent_reference_error():
 def test_quam_component_reference():
     root = QuamRootTest(quam_elem=QuamComponentTest(test_str="hi"), quam_elem_list=[])
 
-    assert root.get_reference() == "#"
+    assert root.get_reference() == "#/"
     assert root.quam_elem.get_reference() == "#/quam_elem"
 
 
@@ -45,7 +45,7 @@ def test_quam_list_reference():
         ],
     )
 
-    assert root.get_reference() == "#"
+    assert root.get_reference() == "#/"
     assert root.quam_elem.get_reference() == "#/quam_elem"
     assert root.quam_elem_list[0].get_reference() == "#/quam_elem_list/0"
     assert root.quam_elem_list[1].get_reference() == "#/quam_elem_list/1"

--- a/tests/utils/test_join_references.py
+++ b/tests/utils/test_join_references.py
@@ -1,0 +1,41 @@
+import pytest
+from quam.utils.string_reference import join_references
+
+
+@pytest.mark.parametrize(
+    "base, relative, expected",
+    [
+        ("#/a/b/c", "#./d/e/f", "#/a/b/c/d/e/f"),
+        ("#/a/b/c", "#../d/e/f", "#/a/b/d/e/f"),
+        ("#/a/b/c", "#../../d/e/f", "#/a/d/e/f"),
+        ("#/a/b/c", "#./a/b/../d/e/f", "#/a/b/c/a/d/e/f"),
+        ("#./a/b/c", "#./d/e/f", "#./a/b/c/d/e/f"),
+        ("#./a/b/c", "#../d/e/f", "#./a/b/d/e/f"),
+        ("#./a/b/c", "#../../d/e/f", "#./a/d/e/f"),
+        ("#./a/b/c", "#./a/b/../d/e/f", "#./a/b/c/a/d/e/f"),
+        ("#../a/b/c", "#./d/e/f", "#../a/b/c/d/e/f"),
+        ("#../a/b/c", "#../d/e/f", "#../a/b/d/e/f"),
+        ("#../a/b/c", "#../../d/e/f", "#../a/d/e/f"),
+        ("#../a/b/c", "#./a/b/../d/e/f", "#../a/b/c/a/d/e/f"),
+        ("#./a", "#../b", "#./b"),
+        ("#./a", "#../../b", "#../b"),
+    ],
+)
+def test_join_references_valid(base, relative, expected):
+    assert join_references(base, relative) == expected
+
+
+@pytest.mark.parametrize(
+    "base, relative",
+    [
+        ("#/a/b/c", "#/d/e/f"),
+        ("#./a/b/c", "#/d/e/f"),
+        ("#../a/b/c", "#/d/e/f"),
+        ("#/a", "#../../b"),
+        ("#./a", "#/b"),
+        ("#./a/b/c", "#./a/b/../d/e/f"),
+    ],
+)
+def test_join_references_invalid(base, relative):
+    with pytest.raises(ValueError):
+        join_references(base, relative)

--- a/tests/utils/test_join_references.py
+++ b/tests/utils/test_join_references.py
@@ -38,3 +38,10 @@ def test_join_references_valid(base, relative, expected):
 def test_join_references_invalid(base, relative):
     with pytest.raises(ValueError):
         join_references(base, relative)
+
+
+def test_join_reference_from_root():
+    assert join_references("#/", "#./") == "#/"
+    assert join_references("#/", "#./a") == "#/a"
+    with pytest.raises(ValueError):
+        join_references("#/", "#../")

--- a/tests/utils/test_join_references.py
+++ b/tests/utils/test_join_references.py
@@ -33,7 +33,6 @@ def test_join_references_valid(base, relative, expected):
         ("#../a/b/c", "#/d/e/f"),
         ("#/a", "#../../b"),
         ("#./a", "#/b"),
-        ("#./a/b/c", "#./a/b/../d/e/f"),
     ],
 )
 def test_join_references_invalid(base, relative):


### PR DESCRIPTION
This PR introduces the kwarg `relative_path` to `QuamBase.get_references()`
This enables the user to retrieve a relative reference w.r.t. a specific QUAM component
Closes #98 

## Examples:
We assume a QuamRoot object with a component "elem".

- `elem.get_reference() == "#/elem"`
- `elem.get_reference(attr="child") == "#/elem/child"`
- `elem.get_reference(relative_path="#./child") == "#/elem/child"`
- `elem.get_reference(relative_path="#../child") == "#/child"`
- `elem.get_reference(relative_path="#./child/grandchild") == "#/elem/child/grandchild"`