### PR TITLE
Fix: Add error message when multiple QuamRoot objects are instantiated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Fixed
 - Fixed issues with parameters being references in a QuamRoot object
 - Fixed `MWFEMAnalogOutputPort.upconverters` not having the correct type
-
+- A warning is raised if a new `QuamRoot` instance is created while a previous one exists.
 
 ## [0.3.8]
 ### Added

--- a/quam/core/quam_classes.py
+++ b/quam/core/quam_classes.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterable
 import sys
 import warnings
-import logging
 from pathlib import Path
 from copy import deepcopy
 from typing import (
@@ -44,8 +43,6 @@ __all__ = [
     "QuamList",
     "quam_dataclass",
 ]
-
-logger = logging.getLogger(__name__)
 
 
 def _get_value_annotation(cls_or_obj: Union[type, object], attr: str) -> type:
@@ -665,7 +662,7 @@ class QuamRoot(QuamBase):
 
     def __post_init__(self):
         if QuamBase._root is not None:
-            logger.warning(
+            warnings.warn(
                 "A new QuamRoot instance has been created while a previous one exists. "
                 "The previous instance should no longer be used."
             )

--- a/quam/core/quam_classes.py
+++ b/quam/core/quam_classes.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 import sys
 import warnings
+import logging
 from pathlib import Path
 from copy import deepcopy
 from typing import (
@@ -43,6 +44,8 @@ __all__ = [
     "QuamList",
     "quam_dataclass",
 ]
+
+logger = logging.getLogger(__name__)
 
 
 def _get_value_annotation(cls_or_obj: Union[type, object], attr: str) -> type:
@@ -661,6 +664,11 @@ class QuamRoot(QuamBase):
     serialiser: AbstractSerialiser = JSONSerialiser
 
     def __post_init__(self):
+        if QuamBase._root is not None:
+            logger.warning(
+                "A new QuamRoot instance has been created while a previous one exists. "
+                "The previous instance should no longer be used."
+            )
         QuamBase._root = self
         super().__post_init__()
 


### PR DESCRIPTION
@JacobHast do you see this warning, or is it filtered by the logs?