### PR TITLE
Feat: Support multiple QuamRoot objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `FrequencyConverter.LO_frequency` setter which updates the local oscillator frequency
 - Added optional `relative_path` to method `QuamBase.get_reference()`
 - Added support for multiple QuamRoot objects
+- Added `QuamBase.get_root()` to get the QuamRoot object of a component
 
 ### Changed
 - `Pulse.integration_weights` now defaults to `#./default_integration_weights`, which returns [(1, pulse.length)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added `string_reference.get_parent_reference` to get the parent reference of a string reference
 - Added `FrequencyConverter.LO_frequency` setter which updates the local oscillator frequency
 - Added optional `relative_path` to method `QuamBase.get_reference()`
+- Added support for multiple QuamRoot objects
 
 ### Changed
 - `Pulse.integration_weights` now defaults to `#./default_integration_weights`, which returns [(1, pulse.length)]

--- a/quam/components/octave.py
+++ b/quam/components/octave.py
@@ -450,7 +450,7 @@ class OctaveOld(QuamComponent):
             octave=self.octave_config,
             connection_headers=self.connection_headers,
         )
-        qm = qmm.open_qm(self._root.generate_config())
+        qm = qmm.open_qm(self.get_root().generate_config())
         return qm
 
     def get_portmap(self):
@@ -459,7 +459,7 @@ class OctaveOld(QuamComponent):
         if self._channel_to_qe is None:
             self._channel_to_qe = {}
 
-        for elem in self._root.iterate_components():
+        for elem in self._get_root().iterate_components():
             if not isinstance(elem, OctaveOldFrequencyConverter):
                 continue
 
@@ -479,7 +479,7 @@ class OctaveOld(QuamComponent):
         for qe in self._channel_to_qe.values():
             self.octave.set_rf_output_mode(qe, RFOutputMode.on)
 
-        for elem in self._root.iterate_components():
+        for elem in self.get_root().iterate_components():
             if not isinstance(elem, InOutIQChannel):
                 continue
             if getattr(elem.frequency_converter_down, "octave", None) is not self:

--- a/quam/core/quam_classes.py
+++ b/quam/core/quam_classes.py
@@ -675,6 +675,13 @@ class QuamRoot(QuamBase):
     serialiser: AbstractSerialiser = JSONSerialiser
 
     def __post_init__(self):
+        if QuamBase._last_instantiated_root is not None:
+            warnings.warn(
+                "Multiple QuamRoot objects were instantiated. Any QuAM component will be "
+                "attached to its specific QuamRoot object. Mixing QuAM components belonging "
+                "to different QuamRoot objects is not recommended as it may lead to "
+                "unexpected results."
+            )
         QuamBase._last_instantiated_root = self
         super().__post_init__()
 

--- a/tests/components/test_octave.py
+++ b/tests/components/test_octave.py
@@ -1,7 +1,13 @@
-from copy import deepcopy
-
+from typing import Dict
+from dataclasses import field
 import pytest
-from quam.components.channels import IQChannel, InOutIQChannel, InOutSingleChannel
+
+from quam.components.channels import (
+    Channel,
+    IQChannel,
+    InOutIQChannel,
+    InOutSingleChannel,
+)
 
 from quam.components.octave import Octave, OctaveUpConverter, OctaveDownConverter
 from quam.core.quam_classes import QuamRoot, quam_dataclass
@@ -10,6 +16,7 @@ from quam.core.quam_classes import QuamRoot, quam_dataclass
 @quam_dataclass
 class OctaveQuAM(QuamRoot):
     octave: Octave
+    channels: Dict[str, Channel] = field(default_factory=dict)
 
 
 @pytest.fixture
@@ -266,7 +273,7 @@ def test_instantiate_octave_default_connectivity(octave):
 
 
 def test_channel_add_RF_outputs(octave, qua_config):
-    OctaveQuAM(octave=octave)
+    machine = OctaveQuAM(octave=octave)
     octave.RF_outputs[2] = OctaveUpConverter(id=2, LO_frequency=2e9)
 
     channel = IQChannel(
@@ -275,7 +282,7 @@ def test_channel_add_RF_outputs(octave, qua_config):
         opx_output_Q=("con1", 2),
         frequency_converter_up="#/octave/RF_outputs/2",
     )
-
+    machine.channels["ch"] = channel
     channel.apply_to_config(qua_config)
 
     expected_cfg_elements = {
@@ -289,7 +296,7 @@ def test_channel_add_RF_outputs(octave, qua_config):
 
 
 def test_channel_add_RF_inputs(octave, qua_config):
-    OctaveQuAM(octave=octave)
+    machine = OctaveQuAM(octave=octave)
     octave.RF_outputs[3] = OctaveUpConverter(id=3, LO_frequency=2e9)
     octave.RF_inputs[4] = OctaveDownConverter(id=4, LO_frequency=2e9)
 
@@ -302,7 +309,7 @@ def test_channel_add_RF_inputs(octave, qua_config):
         frequency_converter_up="#/octave/RF_outputs/3",
         frequency_converter_down="#/octave/RF_inputs/4",
     )
-
+    machine.channels["ch"] = channel
     channel.apply_to_config(qua_config)
 
     expected_cfg_elements = {

--- a/tests/config/test_config_settings.py
+++ b/tests/config/test_config_settings.py
@@ -72,7 +72,7 @@ def test_generate_after_property():
 
         @property
         def config_settings(self):
-            return {"after": [self._root.second_component]}
+            return {"after": [self.get_root().second_component]}
 
     root = Root(
         first_component=ComponentProperty(name="first"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,13 +20,6 @@ def BareQuamComponent():
     return BareQuamComponent
 
 
-@pytest.fixture(scope="function", autouse=True)
-def remove_quam_root():
-    from quam.core import QuamBase
-
-    QuamBase._root = None
-
-
 @pytest.fixture
 def qua_config():
     from quam.core.qua_config_template import qua_config_template

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,13 @@ def BareQuamComponent():
     return BareQuamComponent
 
 
+@pytest.fixture(scope="function", autouse=True)
+def remove_quam_root():
+    from quam.core import QuamBase
+
+    QuamBase._last_instantiated_root = None
+
+
 @pytest.fixture
 def qua_config():
     from quam.core.qua_config_template import qua_config_template

--- a/tests/examples/superconducting_qubits/test_transmon.py
+++ b/tests/examples/superconducting_qubits/test_transmon.py
@@ -281,7 +281,7 @@ def test_instantiation_single_element():
     assert quam.qubit.id == 0
     assert quam.qubit.xy is None
 
-    assert quam.qubit._root is quam
+    assert quam.qubit.get_root() is quam
 
 
 def test_instantiation_single_nested_element():
@@ -290,6 +290,6 @@ def test_instantiation_single_nested_element():
     assert quam.qubit.xy.mixer.name == "q0.xy.mixer"
     assert quam.qubit.xy.mixer.local_oscillator_frequency == 6e9
 
-    assert quam.qubit._root is quam
-    assert quam.qubit.xy._root is quam
-    assert quam.qubit.xy.mixer._root is quam
+    assert quam.qubit.get_root() is quam
+    assert quam.qubit.xy.get_root() is quam
+    assert quam.qubit.xy.mixer.get_root() is quam

--- a/tests/quam_base/referencing/test_quam_class_referencing.py
+++ b/tests/quam_base/referencing/test_quam_class_referencing.py
@@ -23,7 +23,7 @@ class QuamComponentTest(QuamComponent):
 
 def test_quam_component_reference_after_initialization(BareQuamRoot):
     quam_elem = QuamComponentTest(int_val=42)
-    assert quam_elem._root is None
+    assert quam_elem.get_root() is None
     quam_elem.int_val = "#/test"
     assert quam_elem.int_val == "#/test"
 

--- a/tests/quam_base/referencing/test_reference_path.py
+++ b/tests/quam_base/referencing/test_reference_path.py
@@ -7,7 +7,7 @@ from quam.core import *
 
 def test_root_reference(BareQuamRoot):
     root = BareQuamRoot()
-    assert root._root is root
+    assert root.get_root() is root
 
     assert root.get_reference() == "#/"
 

--- a/tests/quam_base/referencing/test_referencing_list.py
+++ b/tests/quam_base/referencing/test_referencing_list.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from quam.core import *
 from quam.utils.string_reference import *
 
@@ -5,6 +6,7 @@ from quam.utils.string_reference import *
 @quam_dataclass
 class BareQuamRoot(QuamRoot):
     a: int = 4
+    quam_list: Optional[QuamList] = None
 
 
 def test_referencing_from_list():

--- a/tests/quam_base/test_multiple_quam.py
+++ b/tests/quam_base/test_multiple_quam.py
@@ -1,0 +1,117 @@
+from typing import Optional
+import warnings
+import pytest
+from quam.core.quam_classes import QuamComponent, QuamRoot, quam_dataclass
+
+
+@quam_dataclass
+class QuamComponentTest(QuamComponent):
+    a: int
+    b: int
+
+
+@quam_dataclass
+class QuamComponentNestedTest(QuamComponentTest):
+    component: Optional[QuamComponentTest] = None
+
+
+@quam_dataclass
+class QuamRootTest(QuamRoot):
+    component: Optional[QuamComponentTest] = None
+
+
+def test_get_root():
+    component = QuamComponentTest(a=1, b=2)
+    assert component.get_root() is None
+
+    machine = QuamRootTest(component=component)
+    assert machine.component.a == 1
+    assert machine.component.b == 2
+    assert machine.component.get_root() == machine
+
+
+def test_get_root_nested():
+    nested_component = QuamComponentTest(a=1, b=2)
+    component = QuamComponentNestedTest(a=1, b=2, component=nested_component)
+
+    assert nested_component.get_root() is None
+    assert component.get_root() is None
+
+    machine = QuamRootTest(component=component)
+    assert machine.component.get_root() == machine
+    assert machine.component.component.get_root() == machine
+
+
+def test_multiple_quam():
+    component = QuamComponentTest(a=1, b=2)
+    machine = QuamRootTest(component=component)
+
+    component2 = QuamComponentTest(a=3, b=4)
+    machine2 = QuamRootTest(component=component2)
+
+    assert component.get_root() == machine
+    assert component2.get_root() == machine2
+
+    assert machine.get_root() == machine
+    assert machine2.get_root() == machine2
+
+
+def test_multiple_quam_nested():
+    nested_component = QuamComponentTest(a=1, b=2)
+    component = QuamComponentNestedTest(a=1, b=2, component=nested_component)
+
+    component2 = QuamComponentTest(a=3, b=4)
+
+    assert nested_component.get_root() is None
+    assert component.get_root() is None
+    assert component2.get_root() is None
+
+    machine = QuamRootTest(component=component)
+    machine2 = QuamRootTest(component=component2)
+
+    assert machine.component.get_root() == machine
+    assert machine.component.component.get_root() == machine
+    assert machine2.component.get_root() == machine2
+    assert machine2.component.get_root() == machine2
+
+
+def test_multiple_quam_reference():
+    component = QuamComponentTest(a=1, b="#/component/a")
+    machine = QuamRootTest(component=component)
+
+    component2 = QuamComponentTest(a=3, b="#/component/a")
+    machine2 = QuamRootTest(component=component2)
+
+    assert component.b == 1
+    assert component2.b == 3
+
+
+def test_detached_root():
+    component = QuamComponentTest(a=1, b=2)
+
+    with pytest.warns(
+        UserWarning, match="No QuamRoot initialized, cannot retrieve reference"
+    ):
+        assert component._get_referenced_value("#/component/a") == "#/component/a"
+
+    machine = QuamRootTest(component=QuamComponentTest(a=4, b=5))
+
+    with pytest.warns(
+        UserWarning,
+        match=("This component is not part of any QuamRoot, using last"),
+    ):
+        assert component._get_referenced_value("#/component/a") == 4
+
+    component2 = QuamComponentTest(a=3, b="#/component/a")
+    QuamRootTest(component=component2)
+
+    with pytest.warns(
+        UserWarning,
+        match=("This component is not part of any QuamRoot, using last"),
+    ):
+        assert component._get_referenced_value("#/component/a") == 3
+
+    machine.component = component
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert component._get_referenced_value("#/component/a") == 1

--- a/tests/quam_base/test_quam_base.py
+++ b/tests/quam_base/test_quam_base.py
@@ -38,14 +38,6 @@ class BareQuamComponent(QuamComponent):
     pass
 
 
-def test_update_quam_component_quam():
-    quam_root = BareQuamRoot()
-    assert QuamComponent._root is quam_root
-
-    quam_component = BareQuamComponent()
-    assert quam_component._root is quam_root
-
-
 @quam_dataclass(eq=False)
 class QuamTest(QuamRoot):
     int_val: int


### PR DESCRIPTION
This PR introduces support for multiple QuamRoot objects.

Previously, the active QuamRoot object was tracked using the class attribute `QuamBase._root`, which is overridden if a new QuamRoot object is created.
In the new implementation, the QuamRoot is determined through `QuamComponent.get_root()`, which recursively follows the parent chain until it finds a QuamRoot. If no QuamRoot is found it returns None.

For backwards compatibility, if the parent chain does not end in a QuamRoot, it will check if a QuamRoot has been instantiated, and if so, return the latest one.

Warnings are still raised if multiple QuamRoot objects are instantiated, and also if a component does not have a QuamRoot in its parent chain

@JacobHast should cover issue #58 
