### PR TITLE
Change dataclasses.dataclass to pydantic.dataclasses.dataclass

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "qm-qua >=1.1.0",
     "qualang-tools >= 0.15.0",
     "typeguard >= 4.1.0",
+    "pydantic >= 2.10.5"
 ]
 
 [project.urls]

--- a/quam/core/__init__.py
+++ b/quam/core/__init__.py
@@ -5,6 +5,6 @@ from .quam_classes import *
 # This will no longer be necessary once we drop support for Python 3.9
 # We also do this at the end of quam_classes.py, but PyCharm also requires it here
 _quam_dataclass = quam_dataclass
-from dataclasses import dataclass as quam_dataclass
+from pydantic.dataclasses import dataclass as quam_dataclass
 
 exec("quam_dataclass = _quam_dataclass")


### PR DESCRIPTION
This change is motivated by the following use-case.

Let's say I create a `QuAM` object to represent my QPU. Since every QuAM component is also a `@quam_dataclass`, I can use Pydantic's dataclass scheme generation feature as follows:

Do this to generate a schema:
```python
schema = TypeAdapter(QuAM).json_schema()
with open("schema.json", "w+") as f:
   json.dump(schema, f, indent=2))
```

Then, if you load the schema into my IDE using a JSON schema mapping, you get required-field checking, type-checking, attribute hints, etc.
[trimmed_output.webm](https://github.com/user-attachments/assets/4c674107-ca03-4769-95d5-8a9385a9de62)

I believe we can enhance the number of schema features we exploit by doing something [like this](https://docs.pydantic.dev/latest/concepts/dataclasses/#__tabbed_2_1):
```python
@quam_dataclass
class XYZ:
        age: Optional[int] = pydantic.dataclasses.field(metadata=dict(
            description="some description"
        )
    )
```
but I haven't tested it.

Could you please run this against tests and consider whether it will break fundamental features of QuAM? If not, I believe it would be a great improvement.