### PR TITLE
Change: new filters that comply with QOP 3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   This provides type hints for the generated config.
 - Add `MWFEMAnalogInputPort.gain_db` to allow for setting the gain of the analog input port
 - Removed warning when multiple QuamRoot objects are instantiated
-- Added `SingleChannel.exponential_filter` and `SingleChannel.high_pass_filter` in compliance with QOP 3.3.
+- Added `SingleChannel.exponential_filter` in compliance with QOP 3.3.
 - Deprecated `SingleChannel.filter_iir_taps` in favor of `SingleChannel.exponential_filter` for the LF-FEM
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,24 @@
 ## [Unreleased]
 
 ### Changed
+
 - `QuamBase.generate_config()` now returns a `DictQuaConfig` instead of a `Dict[str, Any]`
   This provides type hints for the generated config.
 - Add `MWFEMAnalogInputPort.gain_db` to allow for setting the gain of the analog input port
 - Removed warning when multiple QuamRoot objects are instantiated
+- Added `SingleChannel.exponential_filter` and `SingleChannel.high_pass_filter` in compliance with QOP 3.3.
+- Deprecated `SingleChannel.filter_fir_taps` and `SingleChannel.filter_iir_taps` in favor of `SingleChannel.feedforward_filter` and `SingleChannel.feedback_filter` (OPX+), or `SingleChannel.exponential_filter` and `SingleChannel.high_pass_filter` (LF-FEM)
 
 ### Fixed
+
 - Fixed `QuamBase.iterate_components()` arg `skip_elems` having the wrongtype
 - Deprecated `thread` argument in favor of `core` in `Channel` when qm >= 1.2.2
 - Fixed `MWFEMAnalogOutputPort.upconverters` not being converted to a dict in the config
 
-
 ## [0.3.9]
+
 ### Added
+
 - Added `QuamBase.set_at_reference` to set a value at a reference
 - Added `string_reference.get_parent_reference` to get the parent reference of a string reference
 - Added `FrequencyConverter.LO_frequency` setter which updates the local oscillator frequency
@@ -22,9 +27,11 @@
 - Added `QuamBase.get_root()` to get the QuamRoot object of a component
 
 ### Changed
+
 - `Pulse.integration_weights` now defaults to `#./default_integration_weights`, which returns [(1, pulse.length)]
 
 ### Fixed
+
 - Fixed issues with parameters being references in a QuamRoot object
 - Fixed `MWFEMAnalogOutputPort.upconverters` not having the correct type
 - A warning is raised if a new `QuamRoot` instance is created while a previous one exists.
@@ -33,56 +40,68 @@
 - `MWChannel.upconverter_frequency` and `MWChannel.LO_frequency` now correctly return the upconverter frequency from the `opx_output` port, supporting both `upconverter_frequency` and `upconverters` specifications.
 
 ## [0.3.8]
+
 ### Added
+
 - Added time tagging to channels
 - Added support for Python 3.12
 
 ### Removed
+
 - Removed support for Python 3.8
 - Added `Pulse.play()` method
 
 ### Fixed
+
 - Change location of port feedforward and feedback filters in config
 - Convert port crosstalk to dict in config, fixing deepcopy issues
 
-
 ## [0.3.7]
+
 ### Added
+
 - Added `WaveformPulse` to allow for pre-defined waveforms.
 
-
 ## [0.3.6]
+
 ### Changed
+
 - Modified `MWChannel` to also have `RF_frequency` and `LO_frequency` to match the signature of `IQChannel`.
   This is done by letting both inherit from a new base class `_OutComplexChannel`.
 
 ## [0.3.5]
+
 ### Added
+
 - Added `DragCosinePulse`.
 - Added support for sticky channels through the `StickyChannelAddon` (see documentation)
 - Added `Channel.thread`, which defaults to None
 - QUAM can now be installed through PyPi
 
 ### Changed
+
 - Aded ports for different hardware. As a consequence we now also support the LF-FEM and MW-FEM
 - `Channel` is now an abstract base class.
 - Moved `intermediate_frequency` to `Channel` from `SingleChannel/IQChannel`.
   The default is `None`. A consequence of this is that `SingleChannel` no longer adds
-    `intermediate_frequency` to the config if it's not set.
-
+  `intermediate_frequency` to the config if it's not set.
 
 ## [0.3.4]
+
 ### Added
+
 - Added `Channel.frame_rotation_2pi` to allow for frame rotation in multiples of 2pi
 - Added `Channel.update_frequency` to allow for updating the frequency of a channel
 - Added `OctaveOld.connectivity` as it was needed for (deprecated) compatibility with multiple OPX instruments
 
 ### Changed
+
 - Allow `QuamBase.get_reference(attr)` to return a reference of one of its attributes
 - Octave RF input 2 has `LO_source = "external"` by default
 - Rename `DragPulse -> DragGaussianPulse`, deprecate `DragPulse`
 
 ### Fixed
+
 - Fix quam object instantiation error when a parameter type uses pipe operator
 - Allow int keys to be serialised / loaded in QuAM using JSONSerialiser
 - Fix type `OctaveUpconverter.triggered_reersed` -> `OctaveUpconverter.triggered_reversed`
@@ -90,16 +109,18 @@
 - Fix filter_fir/iir_taps being passed as QuamList when generating config, resulting in an error due to parent reassignment
 - Fix warning messages in QuamComponent instantiation
 
-
 ## [0.3.3]
+
 ### Added
+
 - Added the following parameters to `IQChannel`: `RF_frequency`, `LO_frequency`, `intermediate_frequency`
 - Added the following properties to `IQChannel`: `inferred_RF_frequency`, `inferred_LO_frequency`, `inferred_intermediate_frequency`
-    These properties can be attached to the relevant parameters to infer the frequency from the remaining two parameters.
+  These properties can be attached to the relevant parameters to infer the frequency from the remaining two parameters.
 - Added `IQChannel.inferred_RF/LO/intermediate_frequency`
   These can be used to infer the frequency from the remaining two frequencies
 
 ### Changed
+
 - Deprecated the `rf_frequency` property in favor of the `RF_frequency` parameter in `IQChannel`
 - Added channel types: `InSingleChannel`, `InIQChannel`, `InSingleOutIQChannel`, `InIQOutSingleChannel`
 - Restructured channels to allow for other channel types.
@@ -107,47 +128,55 @@
 - Deprecated `IQChannel.rf_frequency` in favor of `IQChannel.RF_frequency`
 
 ### Fixed
+
 - Fixed dataclass ClassVar parameters being wrongly classified as optional or required dataclass args
 - Made `ConstantReadoutPulse` a dataclass, and removed some wrong docstring
 
-
 ## [0.3.2]
+
 ### Added
+
 - Added full QuAM documentation, including web hosting
 - Added `BasicQuAM` to QuAM components
 
 ### Fixed
+
 - Fix error where a numpy array of integration weights raises an error
 - Fix instantiation of a dictionary where the value is a reference
 - Fix optional parameters of a quam component parent class were sometimes categorized as a required parameter (ReadoutPulse)
 
-
 ## [0.3.1]
+
 ### Added
+
 - Add optional `config_settings` property to quam components indicating that they should be called before/after other components when generating QUA configuration
 - Added `InOutIQChannel.measure_accumulated/sliced`
 - Added `ReadoutPulse`. All readout pulses can now be created simply by inheriting from the `ReadoutPulse` and the non-readout variant.
 - Added `Channel.set_dc_offset`
 
 ### Changed
+
 - Pulses with `pulse.axis_angle = None` are now compatible with an `IQChannel` as all signal on the I port.
 
 ### Fixed
+
 - Switched channel `RF_inputs` and `RF_outputs` for Octave
 - Loading QuAM components when the expected type is a union or the actual type is a list
   no longer raises an error
-- The qua config entries from OctaveUpConverter entries I/Q_connection were of type 
+- The qua config entries from OctaveUpConverter entries I/Q_connection were of type
   QuamList, resulting in errors during deepcopy. Converted to tuple
 
-
 ## [0.3.0]
+
 ### Added
+
 - Added InOutSingleChannel
 - Added optional `config_settings` property to quam components indicating that they should be called before/after other components when generating QUA configuration
 - Added support for the new Octave API.
 - Added support for `Literal` types in QuAM
 
 ### Changed
+
 - Changed `InOutIQChannel.input_offset_I/Q` to `InOutIQChannel.opx_input_offset_I/Q`
 - Renamed `SingleChannel.output_offset` -> `SingleChannel.opx_output_offset`
 - Pulse behaviour modifications to allow pulses to be attached to objects other than channels. Changes conist of following components
@@ -166,6 +195,7 @@
 - Channel frequency converter default types are now `BaseFrequencyConverter` which has fewer attributes than `FrequencyConverter`. This is to make it compatible with the new Octave API.
 
 ### Fixed
+
 - Don't raise instantiation error when required_type is not a class
 - Add support for QuAM component sublist type: List[List[...]]
 - Channel offsets (e.g. `SingleChannel.opx_output_offset`) are ensured to be unique, otherwise a warning is raised
@@ -175,15 +205,18 @@
 - JSON serializer doesn't break if an item is added to ignore that isn't part of QuAM
 - Allow `QuamDict` keys to be integers
 
-
 ## [0.2.2] -
+
 ### Added
+
 - Overwriting a reference now raises an error. A referencing attribute must first be set to None
 
-
 ## [0.2.1] -
+
 This release primarily targets Octave compatibility
+
 ### Changes
+
 - `FrequencyConverter` and `LocalOscillator` both have a method `configure()` added
 - Improve documentation of `IQChannel`, `InOutIQChannel`
 - Various fixes to Octave, including removal of any code specific to a single QuAM setup
@@ -191,22 +224,25 @@ This release primarily targets Octave compatibility
 - Remove `_value_annotation` when calling `get_dataclass_attr_annotation`
 - Slightly expanded error message in `validate_obj_type`
 
-
 ## [0.2.0] -
+
 ### Changed
+
 - Quam components now user `@quam_dataclass` decorator instead of `@dataclass(kw_only=True)`
 
-
 ## [0.1.1] -
+
 Only registering changes from November 29th
 
 ### Added
+
 - Add `Pulse.axis_angle` for most pulses that specifies axis on IQ plane if defined
 - Add `validate` kwarg to `pulse.play()`
 - Add `InOutIQChannel.measure()`
 - Add `ArbitraryWeightsReadoutPulse`
 
 ### Changed
+
 - `InOutIQChannel.frequency_converter_down` default is None
 - Change `ConstantReadoutPulse` -> `ConstantWeightsReadoutPulse`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add `MWFEMAnalogInputPort.gain_db` to allow for setting the gain of the analog input port
 - Removed warning when multiple QuamRoot objects are instantiated
 - Added `SingleChannel.exponential_filter` and `SingleChannel.high_pass_filter` in compliance with QOP 3.3.
-- Deprecated `SingleChannel.filter_fir_taps` and `SingleChannel.filter_iir_taps` in favor of `SingleChannel.feedforward_filter` and `SingleChannel.feedback_filter` (OPX+), or `SingleChannel.exponential_filter` and `SingleChannel.high_pass_filter` (LF-FEM)
+- Deprecated `SingleChannel.filter_iir_taps` in favor of `SingleChannel.exponential_filter` for the LF-FEM
 
 ### Fixed
 

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -58,7 +58,6 @@ from qm.qua._dsl import (
     StreamType,
 )
 
-
 __all__ = [
     "Channel",
     "DigitalOutputChannel",
@@ -694,9 +693,20 @@ class SingleChannel(Channel):
 
         filter_fir_taps = self.filter_fir_taps
         if filter_fir_taps is not None:
+            warnings.warn(
+                "SingleChannel.filter_fir_taps have moved to the analog output port "
+                "property 'feedforward_filter'. Please update your QUAM state.",
+                DeprecationWarning,
+            )
             filter_fir_taps = list(filter_fir_taps)
         filter_iir_taps = self.filter_iir_taps
         if filter_iir_taps is not None:
+            warnings.warn(
+                "SingleChannel.filter_iir_taps have moved to the analog output port "
+                "property 'feedback_filter' (OPX+), or 'exponential_filter' and "
+                "'high_pass_filter' (LF-FEM). Please update your QUAM state.",
+                DeprecationWarning,
+            )
             filter_iir_taps = list(filter_iir_taps)
 
         if isinstance(self.opx_output, LFAnalogOutputPort):

--- a/quam/components/ports/analog_outputs.py
+++ b/quam/components/ports/analog_outputs.py
@@ -61,11 +61,14 @@ class LFFEMAnalogOutputPort(LFAnalogOutputPort, FEMPort):
     def get_port_properties(self) -> Dict[str, Any]:
         port_properties = super().get_port_properties()
         if self.exponential_filter is not None:
-            port_properties["exponential_filter"] = list(self.exponential_filter)
+            filter_properties = port_properties.setdefault("filter", {})
+            filter_properties["exponential"] = list(self.exponential_filter)
+            if "feedback" in filter_properties:
+                raise ValueError(
+                    "LFFEMAnalogOutputPort: Please only specify 'exponential_filter' "
+                    "if QOP >=3.3.0, or 'feedback_filter' if QOP < 3.3.0, not both"
+                )
 
-        # High-pass filter not yet supported
-        # if self.high_pass_filter is not None:
-        #     port_properties["high_pass_filter"] = self.high_pass_filter
         port_properties["sampling_rate"] = self.sampling_rate
         if self.sampling_rate == 1e9:
             port_properties["upsampling_mode"] = self.upsampling_mode

--- a/quam/components/ports/analog_outputs.py
+++ b/quam/components/ports/analog_outputs.py
@@ -1,9 +1,8 @@
 from abc import ABC
-from typing import Any, ClassVar, Dict, List, Literal, Optional
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Tuple
 
 from quam.components.ports.base_ports import BasePort, FEMPort, OPXPlusPort
 from quam.core import quam_dataclass
-
 
 __all__ = [
     "LFAnalogOutputPort",
@@ -55,10 +54,16 @@ class LFFEMAnalogOutputPort(LFAnalogOutputPort, FEMPort):
     fem_type: ClassVar[str] = "LF"
     sampling_rate: float = 1e9  # Either 1e9 or 2e9
     upsampling_mode: Literal["mw", "pulse"] = "mw"
+    exponential_filter: Optional[List[Tuple[float, float]]] = None
+    high_pass_filter: Optional[List[Tuple[float, float]]] = None
     output_mode: Literal["direct", "amplified"] = "direct"
 
     def get_port_properties(self) -> Dict[str, Any]:
         port_properties = super().get_port_properties()
+        if self.exponential_filter is not None:
+            port_properties["exponential_filter"] = list(self.exponential_filter)
+        if self.high_pass_filter is not None:
+            port_properties["high_pass_filter"] = list(self.high_pass_filter)
         port_properties["sampling_rate"] = self.sampling_rate
         if self.sampling_rate == 1e9:
             port_properties["upsampling_mode"] = self.upsampling_mode

--- a/quam/components/ports/analog_outputs.py
+++ b/quam/components/ports/analog_outputs.py
@@ -55,15 +55,17 @@ class LFFEMAnalogOutputPort(LFAnalogOutputPort, FEMPort):
     sampling_rate: float = 1e9  # Either 1e9 or 2e9
     upsampling_mode: Literal["mw", "pulse"] = "mw"
     exponential_filter: Optional[List[Tuple[float, float]]] = None
-    high_pass_filter: Optional[List[Tuple[float, float]]] = None
+    # high_pass_filter: Optional[float] = None  # Not yet supported
     output_mode: Literal["direct", "amplified"] = "direct"
 
     def get_port_properties(self) -> Dict[str, Any]:
         port_properties = super().get_port_properties()
         if self.exponential_filter is not None:
             port_properties["exponential_filter"] = list(self.exponential_filter)
-        if self.high_pass_filter is not None:
-            port_properties["high_pass_filter"] = list(self.high_pass_filter)
+
+        # High-pass filter not yet supported
+        # if self.high_pass_filter is not None:
+        #     port_properties["high_pass_filter"] = self.high_pass_filter
         port_properties["sampling_rate"] = self.sampling_rate
         if self.sampling_rate == 1e9:
             port_properties["upsampling_mode"] = self.upsampling_mode

--- a/tests/components/ports/test_lf_fem_analog_ports.py
+++ b/tests/components/ports/test_lf_fem_analog_ports.py
@@ -178,3 +178,46 @@ def test_lf_fem_analog_input_port():
             }
         }
     }
+
+
+def test_lf_fem_analog_output_port_exponential_filter():
+    port = LFFEMAnalogOutputPort("con1", 1, 2)
+    port.exponential_filter = [(10, 0.1), (20, 0.2)]
+    assert port.get_port_properties() == {
+        "delay": 0,
+        "shareable": False,
+        "output_mode": "direct",
+        "sampling_rate": 1e9,
+        "upsampling_mode": "mw",
+        "filter": {"exponential": [(10, 0.1), (20, 0.2)]},
+    }
+
+    # Add feedforward filter alongside exponential filter
+    port.feedforward_filter = [0.7, 0.2, 0.1]
+    assert port.get_port_properties() == {
+        "delay": 0,
+        "shareable": False,
+        "output_mode": "direct",
+        "sampling_rate": 1e9,
+        "upsampling_mode": "mw",
+        "filter": {
+            "exponential": [(10, 0.1), (20, 0.2)],
+            "feedforward": [0.7, 0.2, 0.1],
+        },
+    }
+
+    # Adding feedback filter should raise ValueError due to QOP version compatibility
+    port.feedback_filter = [0.3, 0.4, 0.5]
+    with pytest.raises(ValueError, match="Please only specify 'exponential_filter' "):
+        port.get_port_properties()
+    # Remove exponential filter and verify feedback filter works
+    port.exponential_filter = None
+    port.feedback_filter = [0.3, 0.4, 0.5]
+    assert port.get_port_properties() == {
+        "delay": 0,
+        "shareable": False,
+        "output_mode": "direct",
+        "sampling_rate": 1e9,
+        "upsampling_mode": "mw",
+        "filter": {"feedforward": [0.7, 0.2, 0.1], "feedback": [0.3, 0.4, 0.5]},
+    }


### PR DESCRIPTION
Adds `LFFEMAnalogOutputPort.exponential_filter` and `LFFEMAnalogOutputPort.high_pass_filter`.

Currently there are no checks that discriminate between QOP version