### PR TITLE
Change/serialise default classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [Unreleased]
+
+### Added
+
+- Add the QUAM config, which can be called from the terminal command `quam config`.
+  This enables adding a default QUAM state path
+- Add the following properties to the `JSONSerialiser`: `content_mapping`, `include_defaults`, and `state_path`.
+
+### Changed
+
+- `JSONSerialiser.content_mapping` structure has been changed from dict `{filename.json: [list of components]}` to `{component: filname.json}`. The previous format is still supported although this raises a warning
+- Remove implicit support for content mapping structure `{filename.json: component} (note the lack of a list). This used to be supported even though it was never mentioned.
+- The default state path for a `QuamRoot` is now retrieved from the environment variable `QUAM_STATE_PATH`, and if this doesn't exist, from the quam config.
+
 ## [0.3.10]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - `JSONSerialiser.content_mapping` structure has been changed from dict `{filename.json: [list of components]}` to `{component: filname.json}`. The previous format is still supported although this raises a warning
 - Remove implicit support for content mapping structure `{filename.json: component} (note the lack of a list). This used to be supported even though it was never mentioned.
 - The default state path for a `QuamRoot` is now retrieved from the environment variable `QUAM_STATE_PATH`, and if this doesn't exist, from the quam config.
+- Add `__class__` to serialisation (`to_dict` method), even if the target class matches the expected type
+- If a specific class can't be imported during instantiation, a warning will be raised and it will load the default class (specified by the type hint) instead
 
 ## [0.3.10]
 

--- a/quam/core/quam_instantiation.py
+++ b/quam/core/quam_instantiation.py
@@ -5,6 +5,7 @@ import types
 import typing
 from typing import TYPE_CHECKING, Dict, Any
 from inspect import isclass
+import warnings
 
 from quam.utils import (
     string_reference,
@@ -359,7 +360,13 @@ def instantiate_quam_class(
     # str_repr = f"{str_repr}.{quam_class.__name__}" if str_repr else quam_class.__name__
 
     if "__class__" in contents:
-        quam_class = get_class_from_path(contents["__class__"])
+        try:
+            quam_class = get_class_from_path(contents["__class__"])
+        except ModuleNotFoundError:
+            warnings.warn(
+                f"Could not instantiate {str_repr} with class {contents['__class__']}, "
+                f"falling back to {quam_class.__name__}"
+            )
 
     if not isinstance(contents, dict):
         raise TypeError(

--- a/tests/components/channels/test_in_out_IQ_channel.py
+++ b/tests/components/channels/test_in_out_IQ_channel.py
@@ -43,8 +43,11 @@ def test_empty_in_out_IQ_channel():
     assert d == {
         "frequency_converter_up": {
             "__class__": "quam.components.hardware.FrequencyConverter",
-            "mixer": {},
-            "local_oscillator": {"frequency": 5000000000.0},
+            "mixer": {"__class__": "quam.components.hardware.Mixer"},
+            "local_oscillator": {
+                "frequency": 5000000000.0,
+                "__class__": "quam.components.hardware.LocalOscillator",
+            },
         },
         "opx_output_I": ("con1", 1),
         "opx_output_Q": ("con1", 2),
@@ -52,6 +55,7 @@ def test_empty_in_out_IQ_channel():
         "opx_input_Q": ("con1", 4),
         "intermediate_frequency": 100000000.0,
         "id": 1,
+        "__class__": "quam.components.channels.InOutIQChannel",
     }
 
     bare_cfg = {
@@ -130,8 +134,11 @@ def test_readout_resonator_with_readout():
     assert d == {
         "frequency_converter_up": {
             "__class__": "quam.components.hardware.FrequencyConverter",
-            "mixer": {},
-            "local_oscillator": {"frequency": 5000000000.0},
+            "mixer": {"__class__": "quam.components.hardware.Mixer"},
+            "local_oscillator": {
+                "frequency": 5000000000.0,
+                "__class__": "quam.components.hardware.LocalOscillator",
+            },
         },
         "opx_output_I": ("con1", 1),
         "opx_output_Q": ("con1", 2),
@@ -146,6 +153,7 @@ def test_readout_resonator_with_readout():
                 "length": 1000,
             }
         },
+        "__class__": "quam.components.channels.InOutIQChannel",
     }
 
     cfg = {
@@ -297,8 +305,11 @@ def test_empty_in_out_IQ_channel_ports():
     assert d == {
         "frequency_converter_up": {
             "__class__": "quam.components.hardware.FrequencyConverter",
-            "mixer": {},
-            "local_oscillator": {"frequency": 5000000000.0},
+            "mixer": {"__class__": "quam.components.hardware.Mixer"},
+            "local_oscillator": {
+                "frequency": 5000000000.0,
+                "__class__": "quam.components.hardware.LocalOscillator",
+            },
         },
         "opx_output_I": {
             "controller_id": "con1",
@@ -322,6 +333,7 @@ def test_empty_in_out_IQ_channel_ports():
         },
         "intermediate_frequency": 100000000.0,
         "id": 1,
+        "__class__": "quam.components.channels.InOutIQChannel",
     }
 
     bare_cfg = {

--- a/tests/components/ports/test_digital_ports.py
+++ b/tests/components/ports/test_digital_ports.py
@@ -22,6 +22,7 @@ def test_opx_plus_digital_output_port():
     assert port.shareable is False
 
     assert port.to_dict() == {
+        "__class__": "quam.components.ports.digital_outputs.OPXPlusDigitalOutputPort",
         "controller_id": "con1",
         "port_id": 2,
     }
@@ -63,6 +64,7 @@ def test_opx_plus_digital_input_port():
     assert port.shareable == False
 
     assert port.to_dict() == {
+        "__class__": "quam.components.ports.digital_inputs.OPXPlusDigitalInputPort",
         "controller_id": "con1",
         "port_id": 2,
     }
@@ -109,6 +111,7 @@ def test_fem_digital_output_port():
     assert port.level == "LVTTL"
 
     assert port.to_dict() == {
+        "__class__": "quam.components.ports.digital_outputs.FEMDigitalOutputPort",
         "controller_id": "con1",
         "fem_id": 1,
         "port_id": 2,

--- a/tests/components/ports/test_lf_fem_analog_ports.py
+++ b/tests/components/ports/test_lf_fem_analog_ports.py
@@ -25,6 +25,7 @@ def test_lf_fem_analog_output_port():
     assert port.upsampling_mode == "mw"
 
     assert port.to_dict() == {
+        "__class__": "quam.components.ports.analog_outputs.LFFEMAnalogOutputPort",
         "controller_id": "con1",
         "fem_id": 1,
         "port_id": 2,
@@ -146,6 +147,7 @@ def test_lf_fem_analog_input_port():
     assert port.sampling_rate == 1e9
 
     assert port.to_dict() == {
+        "__class__": "quam.components.ports.analog_inputs.LFFEMAnalogInputPort",
         "controller_id": "con1",
         "fem_id": 1,
         "port_id": 2,

--- a/tests/components/ports/test_mw_fem_analog_ports.py
+++ b/tests/components/ports/test_mw_fem_analog_ports.py
@@ -30,6 +30,7 @@ def test_mw_fem_analog_output_port():
     assert port.full_scale_power_dbm == -11
 
     assert port.to_dict() == {
+        "__class__": "quam.components.ports.analog_outputs.MWFEMAnalogOutputPort",
         "controller_id": "con1",
         "fem_id": 1,
         "port_id": 2,
@@ -92,6 +93,7 @@ def test_mw_fem_analog_input_ports():
     assert port.shareable == False
 
     assert port.to_dict() == {
+        "__class__": "quam.components.ports.analog_inputs.MWFEMAnalogInputPort",
         "controller_id": "con1",
         "fem_id": 1,
         "port_id": 2,

--- a/tests/components/pulses/test_pulses.py
+++ b/tests/components/pulses/test_pulses.py
@@ -61,7 +61,9 @@ def test_channel():
     channel = Channel()
     d = channel.to_dict()
 
-    assert d == {}
+    assert d == {
+        "__class__": "quam.components.channels.Channel",
+    }
 
 
 def test_IQ_channel():
@@ -75,13 +77,16 @@ def test_IQ_channel():
     )
     d = IQ_channel.to_dict()
     assert d == {
+        "__class__": "quam.components.channels.IQChannel",
         "opx_output_I": 0,
         "opx_output_Q": 1,
         "intermediate_frequency": 100e6,
         "frequency_converter_up": {
             "__class__": "quam.components.hardware.FrequencyConverter",
-            "mixer": {},
-            "local_oscillator": {},
+            "mixer": {"__class__": "quam.components.hardware.Mixer"},
+            "local_oscillator": {
+                "__class__": "quam.components.hardware.LocalOscillator",
+            },
         },
     }
 

--- a/tests/components/pulses/test_waveform_pulse.py
+++ b/tests/components/pulses/test_waveform_pulse.py
@@ -33,6 +33,7 @@ def test_waveform_pulse_IQ_mismatch():
 def test_waveform_pulse_to_dict():
     pulse = WaveformPulse(waveform_I=[1, 2, 3], waveform_Q=[4, 5, 6])
     assert pulse.to_dict() == {
+        "__class__": "quam.components.pulses.WaveformPulse",
         "waveform_I": [1, 2, 3],
         "waveform_Q": [4, 5, 6],
     }

--- a/tests/components/test_octave.py
+++ b/tests/components/test_octave.py
@@ -334,13 +334,21 @@ def test_load_octave(octave):
     d_expected = {
         "__class__": "test_octave.OctaveQuAM",
         "octave": {
-            "RF_inputs": {1: {"id": 1}, 2: {"id": 2, "LO_source": "external"}},
+            "__class__": "quam.components.octave.Octave",
+            "RF_inputs": {
+                1: {"id": 1, "__class__": "quam.components.octave.OctaveDownConverter"},
+                2: {
+                    "id": 2,
+                    "LO_source": "external",
+                    "__class__": "quam.components.octave.OctaveDownConverter",
+                },
+            },
             "RF_outputs": {
-                1: {"id": 1},
-                2: {"id": 2},
-                3: {"id": 3},
-                4: {"id": 4},
-                5: {"id": 5},
+                1: {"id": 1, "__class__": "quam.components.octave.OctaveUpConverter"},
+                2: {"id": 2, "__class__": "quam.components.octave.OctaveUpConverter"},
+                3: {"id": 3, "__class__": "quam.components.octave.OctaveUpConverter"},
+                4: {"id": 4, "__class__": "quam.components.octave.OctaveUpConverter"},
+                5: {"id": 5, "__class__": "quam.components.octave.OctaveUpConverter"},
             },
             "ip": "127.0.0.1",
             "name": "octave1",

--- a/tests/examples/superconducting_qubits/test_transmon.py
+++ b/tests/examples/superconducting_qubits/test_transmon.py
@@ -165,15 +165,20 @@ def test_transmon_add_pulse():
 
     quam_dict = transmon.to_dict()
     expected_quam_dict = {
+        "__class__": "quam.examples.superconducting_qubits.components.Transmon",
         "id": 1,
         "xy": {
+            "__class__": "quam.components.channels.IQChannel",
             "intermediate_frequency": 100000000.0,
             "opx_output_I": ("con1", 1),
             "opx_output_Q": ("con1", 2),
             "frequency_converter_up": {
                 "__class__": "quam.components.hardware.FrequencyConverter",
-                "mixer": {},
-                "local_oscillator": {"frequency": 5000000000.0},
+                "mixer": {"__class__": "quam.components.hardware.Mixer"},
+                "local_oscillator": {
+                    "frequency": 5000000000.0,
+                    "__class__": "quam.components.hardware.LocalOscillator",
+                },
             },
             "operations": {
                 "X180": {

--- a/tests/quam_base/referencing/test_quam_root_referencing.py
+++ b/tests/quam_base/referencing/test_quam_root_referencing.py
@@ -27,6 +27,6 @@ def test_quam_root_reference_to_dict():
         d = root.to_dict()
         assert d == {
             "a": "#/b",
-            "b": {},
+            "b": {"__class__": "test_quam_root_referencing.Component"},
             "__class__": "test_quam_root_referencing.Root",
         }

--- a/tests/quam_base/test_to_dict.py
+++ b/tests/quam_base/test_to_dict.py
@@ -53,7 +53,11 @@ class QuamBasicComponent(QuamComponent):
 def test_quam_component_to_dict_basic():
     elem = QuamBasicComponent(a=42, b="foo")
 
-    assert elem.to_dict() == {"a": 42, "b": "foo"}
+    assert elem.to_dict() == {
+        "a": 42,
+        "b": "foo",
+        "__class__": "test_to_dict.QuamBasicComponent",
+    }
 
 
 def test_quam_component_to_dict_nested():
@@ -70,6 +74,9 @@ def test_quam_component_to_dict_nested():
         "a": 42,
         "b": "foo",
         "c": {"a": 42, "b": "foo", "__class__": "test_to_dict.QuamBasicComponent"},
+        "__class__": (
+            "test_to_dict.test_quam_component_to_dict_nested.<locals>.QuamNestedComponent"
+        ),
     }
 
 
@@ -81,36 +88,55 @@ def test_to_dict_nondefault():
         optional_list: List[int] = field(default_factory=list)
 
     quam_component = QuamBasicComponent(required_val=42)
-    assert quam_component.to_dict() == {"required_val": 42}
+    assert quam_component.to_dict() == {
+        "required_val": 42,
+        "__class__": "test_to_dict.test_to_dict_nondefault.<locals>.QuamBasicComponent",
+    }
     assert quam_component.to_dict(include_defaults=True) == {
         "required_val": 42,
         "optional_val": 42,
         "optional_list": [],
+        "__class__": "test_to_dict.test_to_dict_nondefault.<locals>.QuamBasicComponent",
     }
 
     quam_component = QuamBasicComponent(required_val=42, optional_val=43)
-    assert quam_component.to_dict() == {"required_val": 42, "optional_val": 43}
+    assert quam_component.to_dict() == {
+        "required_val": 42,
+        "optional_val": 43,
+        "__class__": "test_to_dict.test_to_dict_nondefault.<locals>.QuamBasicComponent",
+    }
     assert quam_component.to_dict(include_defaults=True) == {
         "required_val": 42,
         "optional_val": 43,
         "optional_list": [],
+        "__class__": "test_to_dict.test_to_dict_nondefault.<locals>.QuamBasicComponent",
     }
 
     quam_component = QuamBasicComponent(required_val=42, optional_list=["test"])
-    assert quam_component.to_dict() == {"required_val": 42, "optional_list": ["test"]}
+    assert quam_component.to_dict() == {
+        "required_val": 42,
+        "optional_list": ["test"],
+        "__class__": "test_to_dict.test_to_dict_nondefault.<locals>.QuamBasicComponent",
+    }
     assert quam_component.to_dict(include_defaults=True) == {
         "required_val": 42,
         "optional_val": 42,
         "optional_list": ["test"],
+        "__class__": "test_to_dict.test_to_dict_nondefault.<locals>.QuamBasicComponent",
     }
 
     quam_component = QuamBasicComponent(required_val=42)
     quam_component.optional_list.append("test")
-    assert quam_component.to_dict() == {"required_val": 42, "optional_list": ["test"]}
+    assert quam_component.to_dict() == {
+        "required_val": 42,
+        "optional_list": ["test"],
+        "__class__": "test_to_dict.test_to_dict_nondefault.<locals>.QuamBasicComponent",
+    }
     assert quam_component.to_dict(include_defaults=True) == {
         "required_val": 42,
         "optional_val": 42,
         "optional_list": ["test"],
+        "__class__": "test_to_dict.test_to_dict_nondefault.<locals>.QuamBasicComponent",
     }
 
 
@@ -120,7 +146,11 @@ def test_omit_default_dict_field():
         d: dict = field(default_factory=dict)
 
     quam_component = QuamBasicComponent()
-    assert quam_component.to_dict() == {}
+    assert quam_component.to_dict() == {
+        "__class__": (
+            "test_to_dict.test_omit_default_dict_field.<locals>.QuamBasicComponent"
+        ),
+    }
 
 
 def test_omit_default_list_field():
@@ -129,7 +159,11 @@ def test_omit_default_list_field():
         l: list = field(default_factory=list)
 
     quam_component = QuamBasicComponent()
-    assert quam_component.to_dict() == {}
+    assert quam_component.to_dict() == {
+        "__class__": (
+            "test_to_dict.test_omit_default_list_field.<locals>.QuamBasicComponent"
+        ),
+    }
 
 
 def test_optional_list_to_dict():
@@ -138,10 +172,19 @@ def test_optional_list_to_dict():
         l: Optional[List[int]] = None
 
     quam_component = QuamBasicComponent()
-    assert quam_component.to_dict() == {}
+    assert quam_component.to_dict() == {
+        "__class__": (
+            "test_to_dict.test_optional_list_to_dict.<locals>.QuamBasicComponent"
+        ),
+    }
 
     quam_component = QuamBasicComponent(l=[1, 2, 3])
-    assert quam_component.to_dict() == {"l": [1, 2, 3]}
+    assert quam_component.to_dict() == {
+        "l": [1, 2, 3],
+        "__class__": (
+            "test_to_dict.test_optional_list_to_dict.<locals>.QuamBasicComponent"
+        ),
+    }
 
 
 def test_list_to_dict_nondefault():
@@ -150,4 +193,9 @@ def test_list_to_dict_nondefault():
         l: int = 42
 
     quam_component = QuamBasicComponent(l=[1, 2, 3])
-    assert quam_component.to_dict() == {"l": [1, 2, 3]}
+    assert quam_component.to_dict() == {
+        "l": [1, 2, 3],
+        "__class__": (
+            "test_to_dict.test_list_to_dict_nondefault.<locals>.QuamBasicComponent"
+        ),
+    }

--- a/tests/serialisation/json_serialiser/test_json_serialiser_save.py
+++ b/tests/serialisation/json_serialiser/test_json_serialiser_save.py
@@ -31,11 +31,19 @@ def test_save_split_content_basic(serialiser, sample_quam_object, tmp_path):
         # Check against the dict representation of the components part
         expected_components = {
             "components": {
-                "comp1": {"id": "c1"},  # value=1 is default
-                "comp2": {"id": "c2", "value": 5},  # value=5 is not default
+                "comp1": {
+                    "id": "c1",
+                    "__class__": "conftest.MockMainComponent",
+                },  # value=1 is default
+                "comp2": {
+                    "id": "c2",
+                    "value": 5,
+                    "__class__": "conftest.MockMainComponent",
+                },  # value=5 is not default
             }
         }
-        assert json.load(f) == expected_components
+        d = json.load(f)
+        assert d == expected_components
     with default_path.open("r", encoding="utf-8") as f:
         assert json.load(f) == {
             "other": "specific_value",


### PR DESCRIPTION
This PR changes the serialisation behaviour such that the `__class__` attribute is always added, even if the target class matches the type hint of the parent class' attribute.
A consequence of this is that the serialised representations become a bit longer, which can be undesirable. However, the serialised representation is now more self-contained as the classes can be determined without requiring the corresponding python classes