### PR TITLE
Change: Deprecate `get_unreferenced_value` in favor of `get_raw_value`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 - The default state path for a `QuamRoot` is now retrieved from the environment variable `QUAM_STATE_PATH`, and if this doesn't exist, from the quam config.
 - Add `__class__` to serialisation (`to_dict` method), even if the target class matches the expected type
 - If a specific class can't be imported during instantiation, a warning will be raised and it will load the default class (specified by the type hint) instead
+- QuAM has been renamed to QUAM
+  - Some root classes have been renamed to CamelCase (e.g. `BasicQuAM` -> `BasicQuam`)
+- Deprecate Quam component method`get_unreferenced_value` in favor of naming `get_raw_value`
 
 
 ## [0.3.10]

--- a/quam/components/quantum_components/qubit.py
+++ b/quam/components/quantum_components/qubit.py
@@ -30,7 +30,7 @@ class Qubit(QuantumComponent):
 
     @property
     def inferred_id(self) -> Union[str, int]:
-        if not str_ref.is_reference(self.get_unreferenced_value("id")):
+        if not str_ref.is_reference(self.get_raw_value("id")):
             return self.id
         elif self.parent is not None:
             name = self.parent.get_attr_name(self)

--- a/quam/components/quantum_components/qubit_pair.py
+++ b/quam/components/quantum_components/qubit_pair.py
@@ -22,7 +22,7 @@ class QubitPair(QuantumComponent):
 
     @property
     def name(self) -> str:
-        if not str_ref.is_reference(self.get_unreferenced_value("id")):
+        if not str_ref.is_reference(self.get_raw_value("id")):
             return self.id
         else:
             return f"{self.qubit_control.name}@{self.qubit_target.name}"

--- a/quam/core/macro/quam_macro.py
+++ b/quam/core/macro/quam_macro.py
@@ -13,7 +13,7 @@ class QuamMacro(QuamComponent, BaseMacro, ABC):
 
     @property
     def inferred_id(self):
-        if not str_ref.is_reference(self.get_unreferenced_value("id")):
+        if not str_ref.is_reference(self.get_raw_value("id")):
             return self.id
         elif self.parent is not None:
             name = self.parent.get_attr_name(self)

--- a/quam/core/quam_classes.py
+++ b/quam/core/quam_classes.py
@@ -450,7 +450,7 @@ class QuamBase(ReferenceClass):
         attr_names = [attr for attr in attr_names if attr not in skip_attrs]
 
         if not follow_references:
-            attrs = {attr: self.get_unreferenced_value(attr) for attr in attr_names}
+            attrs = {attr: self.get_raw_value(attr) for attr in attr_names}
         else:
             attrs = {attr: getattr(self, attr) for attr in attr_names}
 
@@ -630,7 +630,7 @@ class QuamBase(ReferenceClass):
             ValueError: If the reference is invalid, e.g. "#./" since it has no
                 attribute.
         """
-        raw_value = self.get_unreferenced_value(attr)
+        raw_value = self.get_raw_value(attr)
         if not string_reference.is_reference(raw_value):
             if not allow_non_reference:
                 raise ValueError(
@@ -650,7 +650,7 @@ class QuamBase(ReferenceClass):
             )
 
         parent_obj = self._get_referenced_value(parent_reference)
-        raw_referenced_value = parent_obj.get_unreferenced_value(ref_attr)
+        raw_referenced_value = parent_obj.get_raw_value(ref_attr)
         if string_reference.is_reference(raw_referenced_value) and isinstance(
             parent_obj, QuamBase
         ):
@@ -980,8 +980,8 @@ class QuamDict(UserDict, QuamBase):
 
         """
         return False
-
-    def get_unreferenced_value(self, attr: str) -> bool:
+    
+    def get_raw_value(self, attr: str) -> Any:
         """Get the value of an attribute without following references.
 
         Args:
@@ -995,7 +995,7 @@ class QuamDict(UserDict, QuamBase):
             return self.__dict__["data"][attr]
         except KeyError as e:
             raise AttributeError(
-                "Cannot get unreferenced value from attribute {attr} that does not"
+                "Cannot get raw (unreferenced)value from attribute {attr} that does not"
                 " exist in {self}"
             ) from e
 

--- a/quam/utils/reference_class.py
+++ b/quam/utils/reference_class.py
@@ -27,12 +27,21 @@ class ReferenceClass:
         """
         raise NotImplementedError
 
-    def get_unreferenced_value(self, attr: str) -> Any:
+    def get_raw_value(self, attr: str) -> Any:
         """Get the value of an attribute without following references.
 
         If the value is a reference, the reference string is returned
         """
         return super().__getattribute__(attr)
+
+
+    def get_unreferenced_value(self, attr: str) -> Any:
+        """Deprecated method. Use `get_raw_value` instead."""
+        warnings.warn(
+            "get_unreferenced_value is deprecated. Use get_raw_value instead.",
+            DeprecationWarning,
+        )
+        return self.get_raw_value(attr)
 
     def __getattribute__(self, attr: str) -> Any:
         attr_val = super().__getattribute__(attr)
@@ -79,7 +88,7 @@ class ReferenceClass:
             return True
 
         try:
-            original_value = self.get_unreferenced_value(attr)
+            original_value = self.get_raw_value(attr)
         except AttributeError:
             return True
 

--- a/tests/components/pulses/test_pulses.py
+++ b/tests/components/pulses/test_pulses.py
@@ -210,7 +210,7 @@ def test_pulses_referenced():
 
     assert machine_loaded.channel.operations["pulse_referenced"] == pulse_loaded
     assert (
-        machine_loaded.channel.operations.get_unreferenced_value("pulse_referenced")
+        machine_loaded.channel.operations.get_raw_value("pulse_referenced")
         == "#./pulse"
     )
 

--- a/tests/quam_base/test_quam_dict.py
+++ b/tests/quam_base/test_quam_dict.py
@@ -29,7 +29,7 @@ def test_empty_quam_dict():
     with pytest.raises(KeyError):
         quam_dict["nonexisting_attr"]
     with pytest.raises(AttributeError):
-        quam_dict.get_unreferenced_value("nonexisting_attr")
+        quam_dict.get_raw_value("nonexisting_attr")
 
     for val in [42, True, False, None]:
         assert not quam_dict._attr_val_is_default("nonexisting_attr", val)
@@ -47,7 +47,7 @@ def test_quam_dict_nonempty():
 
     assert quam_dict.val1 == 42
     assert quam_dict["val1"] == 42
-    assert quam_dict.get_unreferenced_value("val1") == 42
+    assert quam_dict.get_raw_value("val1") == 42
 
     for val in [42, True, False, None]:
         assert not quam_dict._attr_val_is_default("val1", val)
@@ -80,7 +80,7 @@ def test_quam_dict_setattr():
     with pytest.raises(KeyError):
         quam_dict["val2"]
     with pytest.raises(AttributeError):
-        quam_dict.get_unreferenced_value("val2")
+        quam_dict.get_raw_value("val2")
 
 
 def test_quam_dict_setitem():
@@ -93,7 +93,7 @@ def test_quam_dict_setitem():
     assert quam_dict.get_attrs() == {"val1": 42}
     assert quam_dict.to_dict() == {"val1": 42}
     assert quam_dict["val1"] == 42
-    assert quam_dict.get_unreferenced_value("val1") == 42
+    assert quam_dict.get_raw_value("val1") == 42
 
 
 def test_inner_quam_dict():
@@ -200,7 +200,7 @@ def test_dict_unreferenced_value():
     d = QuamDict(val1="#./val2", val2=42)
     assert d.val1 == 42
     assert d.val2 == 42
-    assert d.get_unreferenced_value("val1") == "#./val2"
+    assert d.get_raw_value("val1") == "#./val2"
 
 
 def test_quam_dict_int_keys():

--- a/tests/quam_base/test_set_at_reference.py
+++ b/tests/quam_base/test_set_at_reference.py
@@ -31,7 +31,7 @@ def test_set_at_reference():
     # Check that the value was set correctly
     assert parent.child.value == 123
     # Reference string should remain unchanged
-    assert parent.get_unreferenced_value("ref_value") == "#./child/value"
+    assert parent.get_raw_value("ref_value") == "#./child/value"
 
 
 def test_set_at_reference_non_reference():
@@ -53,8 +53,8 @@ def test_set_at_reference_invalid_reference():
 
 def test_unreferenced_value():
     root = RootQuam(parent=ParentQuam(child=ChildQuam()))
-    assert root.get_unreferenced_value("abs_ref") == "#/parent/child/value"
-    assert root.parent.get_unreferenced_value("ref_value") == "#./child/value"
+    assert root.get_raw_value("abs_ref") == "#/parent/child/value"
+    assert root.parent.get_raw_value("ref_value") == "#./child/value"
 
 
 def test_set_at_absolute_reference():
@@ -67,7 +67,7 @@ def test_set_at_absolute_reference():
     # Check that the value was set correctly
     assert root.parent.child.value == 456
     # Reference string should remain unchanged
-    assert root.get_unreferenced_value("abs_ref") == "#/parent/child/value"
+    assert root.get_raw_value("abs_ref") == "#/parent/child/value"
 
 
 def test_set_at_absolute_reference_invalid():
@@ -91,8 +91,8 @@ def test_set_double_reference():
     parent = ParentQuam(child=double_child, ref_value="#./child/value")
 
     assert parent.ref_value == 42
-    assert parent.get_unreferenced_value("ref_value") == "#./child/value"
-    assert parent.child.get_unreferenced_value("value") == "#./child/value"
+    assert parent.get_raw_value("ref_value") == "#./child/value"
+    assert parent.child.get_raw_value("value") == "#./child/value"
 
     # Set value through double reference
     parent.set_at_reference("ref_value", 789)
@@ -103,8 +103,8 @@ def test_set_double_reference():
     assert parent.ref_value == 789
 
     # Reference string should remain unchanged
-    assert parent.get_unreferenced_value("ref_value") == "#./child/value"
-    assert double_child.get_unreferenced_value("value") == "#./child/value"
+    assert parent.get_raw_value("ref_value") == "#./child/value"
+    assert double_child.get_raw_value("value") == "#./child/value"
 
 
 def test_set_nonexistent_double_reference():
@@ -147,9 +147,9 @@ def test_set_triple_reference():
     parent = ParentQuam(child=triple_child, ref_value="#./child/value")
 
     assert parent.ref_value == 42
-    assert parent.get_unreferenced_value("ref_value") == "#./child/value"
-    assert parent.child.get_unreferenced_value("value") == "#./child/value"
-    assert parent.child.child.get_unreferenced_value("value") == "#./child/value"
+    assert parent.get_raw_value("ref_value") == "#./child/value"
+    assert parent.child.get_raw_value("value") == "#./child/value"
+    assert parent.child.child.get_raw_value("value") == "#./child/value"
 
     # Set value through triple reference
     parent.set_at_reference("ref_value", 789)
@@ -161,9 +161,9 @@ def test_set_triple_reference():
     assert parent.ref_value == 789
 
     # Reference string should remain unchanged
-    assert parent.get_unreferenced_value("ref_value") == "#./child/value"
-    assert triple_child.get_unreferenced_value("value") == "#./child/value"
-    assert triple_child.child.get_unreferenced_value("value") == "#./child/value"
+    assert parent.get_raw_value("ref_value") == "#./child/value"
+    assert triple_child.get_raw_value("value") == "#./child/value"
+    assert triple_child.child.get_raw_value("value") == "#./child/value"
 
 
 def test_set_at_reference_allow_non_reference():


### PR DESCRIPTION
The QUAM method `get_unreferenced_value` naming was found to be confusing. The method has therefore been renamed to `get_raw_value`.

The method `get_unreferenced_value` still exists, but now raises a deprecation warning and redirects to `get_raw_value`

Also addresses #127 @JacobHast 