### PR TITLE
Fix: get_attr_name fails with references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Fixed
+
+- Fixed `QuamBase.get_attr_name()` failing when an attribute was a reference.
+
 ## [0.4.0]
 
 ### Added

--- a/quam/core/quam_classes.py
+++ b/quam/core/quam_classes.py
@@ -307,7 +307,7 @@ class QuamBase(ReferenceClass):
             AttributeError if not found.
         """
         for attr_name in self._get_attr_names():
-            if getattr(self, attr_name) is attr_val:
+            if self.get_raw_value(attr_name) is attr_val:
                 return attr_name
         else:
             raise AttributeError(
@@ -963,7 +963,7 @@ class QuamDict(UserDict, QuamBase):
             AttributeError if not found.
         """
         for attr_name in self._get_attr_names():
-            if attr_name in self and self[attr_name] is attr_val:
+            if attr_name in self and self.get_raw_value(attr_name) is attr_val:
                 return attr_name
         else:
             raise AttributeError(

--- a/tests/quam_base/test_quam_base.py
+++ b/tests/quam_base/test_quam_base.py
@@ -2,7 +2,7 @@ from typing import List
 from dataclasses import is_dataclass, field
 import pytest
 
-from quam.core import *
+from quam.core import QuamBase, QuamRoot, QuamComponent, QuamDict, quam_dataclass
 
 
 def test_error_create_base_classes_directly():
@@ -259,3 +259,22 @@ def test_parent_attr_name(BareQuamComponent):
     outer_quam_component.quam_component = None
     with pytest.raises(AttributeError):
         inner_quam_component.parent.get_attr_name(inner_quam_component)
+
+
+def test_get_attr_name_with_reference():
+    @quam_dataclass
+    class TestQuamComponent(QuamComponent):
+        a: dict
+        b: dict
+
+    component = TestQuamComponent(a="#./b", b={"value": 43})
+    
+    assert component.a is component.b
+    assert component.get_attr_name(component.b) == "b"
+
+
+def test_quam_dict_get_attr_name_with_reference():
+    d = QuamDict(a="#./b", b={"value": 42})
+
+    assert d.a is d.b
+    assert d.get_attr_name(d.b) == "b"


### PR DESCRIPTION
The functions `QuamDict/QuamComponent.get_attr_name()` did not take into account that its attributes could be references. As a result, some things such as extracting the proper references and performing state updates could fail.
For example, this used to fail:

```python
    d = QuamDict(a="#./b", b={"value": 42})

    assert d.a is d.b
    assert d.get_attr_name(d.b) == "b"
```