### PR TITLE
Feat: Add duration and fidelity properties to QuamMacro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- Added `duration` and `fidelity` as optional parameters to `QuamMacro`
+
 ### Fixed
 
 - Fixed `QuamBase.get_attr_name()` failing when an attribute was a reference.

--- a/quam/core/macro/quam_macro.py
+++ b/quam/core/macro/quam_macro.py
@@ -1,8 +1,8 @@
 from abc import ABC
+from typing import Optional
 from quam.core.quam_classes import quam_dataclass, QuamComponent
 from quam.utils import string_reference as str_ref
 from quam.core.macro.base_macro import BaseMacro
-
 
 __all__ = ["QuamMacro"]
 
@@ -10,6 +10,8 @@ __all__ = ["QuamMacro"]
 @quam_dataclass
 class QuamMacro(QuamComponent, BaseMacro, ABC):
     id: str = "#./inferred_id"
+    duration: Optional[float] = None
+    fidelity: Optional[float] = None
 
     @property
     def inferred_id(self):


### PR DESCRIPTION
This pull request introduces new optional parameters `duration` and `fidelity` to the `QuamMacro` class and updates the changelog to reflect these additions. These changes enhance the flexibility of the `QuamMacro` class by allowing additional configuration options.

### Enhancements to `QuamMacro`:

* [`quam/core/macro/quam_macro.py`](diffhunk://#diff-07e27e3ac017d38369179740c7a8765c07a3c7ea9d2ddddf4f5f6fcac45703d4R2-R14): Added `duration` and `fidelity` as optional parameters to the `QuamMacro` class, using the `Optional` type from `typing`.

### Documentation updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R6): Updated the changelog to include the addition of `duration` and `fidelity` as optional parameters to `QuamMacro`.