### PR TITLE
Fix: time_of_flight default from 24 ns to 140 ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Fixed `QuamBase.get_attr_name()` failing when an attribute was a reference.
 - Fixed arbitrary waveforms on IQ/MW channels not converting Q component to list consistently
+- Changed default `time_of_flight` from 24 ns to 140 ns to fix error on newer qm-qua versions
+  - 140 ns seems like a reasonable default for most channels
 
 ## [0.4.0]
 

--- a/docs/components/octave.md
+++ b/docs/components/octave.md
@@ -214,7 +214,7 @@ qua_config = machine.generate_config()
       "intermediate_frequency": 0.0,
       "RF_inputs": { "port": ["octave1", 2] },
       "smearing": 0,
-      "time_of_flight": 24,
+      "time_of_flight": 140,
       "RF_outputs": { "port": ["octave1", 1] }
     }
   },

--- a/docs/demonstration.md
+++ b/docs/demonstration.md
@@ -211,7 +211,7 @@ QUAM:
         intermediate_frequency: 0.0
         opx_input_I: ('con1', 1)
         opx_input_Q: ('con1', 2)
-        time_of_flight: 24
+        time_of_flight: 140
         smearing: 0
         opx_input_offset_I: None
         opx_input_offset_Q: None
@@ -268,7 +268,7 @@ QUAM:
         intermediate_frequency: 0.0
         opx_input_I: ('con1', 1)
         opx_input_Q: ('con1', 2)
-        time_of_flight: 24
+        time_of_flight: 140
         smearing: 0
         opx_input_offset_I: None
         opx_input_offset_Q: None
@@ -445,7 +445,7 @@ qua_config = machine.generate_config()
             "operations": {"readout": "IQ0.readout.pulse"},
             "outputs": {"out1": ("con1", 1), "out2": ("con1", 2)},
             "smearing": 0,
-            "time_of_flight": 24,
+            "time_of_flight": 140,
         },
         "IQ1": {
             "intermediate_frequency": 0.0,
@@ -458,7 +458,7 @@ qua_config = machine.generate_config()
             "operations": {},
             "outputs": {"out1": ("con1", 1), "out2": ("con1", 2)},
             "smearing": 0,
-            "time_of_flight": 24,
+            "time_of_flight": 140,
         },
         "q0.xy": {
             "intermediate_frequency": 100000000.0,

--- a/docs/examples/Gate-Level Operations.ipynb
+++ b/docs/examples/Gate-Level Operations.ipynb
@@ -1,768 +1,768 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Gate Operations"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
-   "source": [
-    "In this guide, we introduce how to build circuit-level QUA programs by focusing on three core concepts:\n",
-    "1. Defining qubits (or qubit pairs)\n",
-    "2. Organizing them within a stateful container (the QUAM)\n",
-    "3. Transforming pulse-level operations into gate-level operations.\n",
-    "\n",
-    "By the end of this tutorial, you will be able to construct a simple program of the form:\n",
-    "```python\n",
-    "with program() as prog:\n",
-    "    X(q1)              # Single-qubit gate\n",
-    "    clifford(q1, 4)    # Clifford gate from a predefined set\n",
-    "    qubit_state = measure(q1)\n",
-    "```\n",
-    "This short snippet will apply specific gate operations to qubit q1 and then measure its state.\n",
-    "\n",
-    "Below is the outline of what we'll cover:\n",
-    "- Defining a custom Transmon qubit class (inheriting from Qubit)\n",
-    "- Creating a stateful QUAM container to hold multiple qubits or qubit pairs\n",
-    "- Registering a qubit pulse macro (e.g., x180) and using it as a gate\n",
-    "- Building custom macros for measurement and more complex gates (Cliffords)\n",
-    "\n",
-    "The goal is to clearly demonstrate the flow from hardware-level pulse definitions all the way to abstract, gate-level instructions in a QUA program."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Defining a Qubit-Level Component"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We'll begin by importing all the modules we need. Then, we'll define a Transmon class that inherits from Qubit.\n",
-    "In this example, a Transmon has an XY channel and an optional resonator channel for readout.\n",
-    "\n",
-    "Inheriting from Qubit allows us to attach hardware-specific parameters (like channels) and any additional properties\n",
-    "relevant to our hardware setup."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "lines_to_end_of_cell_marker": 0,
-    "lines_to_next_cell": 1
-   },
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2025-03-31 19:28:57,239 - qm - INFO     - Starting session: b8fbbf60-cf4e-4d58-b481-e34d53690c36\n"
-     ]
-    }
-   ],
-   "source": [
-    "from typing import Dict, Optional\n",
-    "import numpy as np\n",
-    "from dataclasses import field\n",
-    "\n",
-    "from quam.components.ports import FEMPortsContainer\n",
-    "from quam.core import QuamRoot, quam_dataclass\n",
-    "from quam.components.quantum_components import Qubit, QubitPair\n",
-    "from quam.components import MWChannel, InOutMWChannel, pulses\n",
-    "\n",
-    "@quam_dataclass\n",
-    "class Transmon(Qubit):\n",
-    "    xy: MWChannel\n",
-    "    resonator: Optional[InOutMWChannel] = None\n",
-    "\n",
-    "@quam_dataclass\n",
-    "class Quam(QuamRoot):\n",
-    "    ports: FEMPortsContainer\n",
-    "    qubits: Dict[str, Qubit] = field(default_factory=dict)\n",
-    "    qubit_pairs: Dict[str, QubitPair] = field(default_factory=dict)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Instantiate QUAM\n",
-    "\n",
-    "QUAM is our top-level container for organizing ports, qubits, and qubit pairs. We start by creating a Quam instance\n",
-    "that includes a FEMPortsContainer, which helps route signals to and from the hardware.\n",
-    "Then we add two Transmon qubits, \"q1\" and \"q2,\" referencing their microwave (MW) channels.\n",
-    "These channels are used for generating pulses that interact with the qubits."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "machine = Quam(ports=FEMPortsContainer())\n",
-    "\n",
-    "## Add qubits\n",
-    "# Here we create the MW output and input ports for q1.\n",
-    "q1_xy_port = machine.ports.get_mw_output(\"con1\", 1, 1, create=True)\n",
-    "q1_resonator_out_port = machine.ports.get_mw_output(\"con1\", 1, 2, create=True)\n",
-    "q1_resonator_in_port = machine.ports.get_mw_input(\"con1\", 1, 2, create=True)\n",
-    "\n",
-    "# Next, we instantiate q1 and specify its XY and resonator channels.\n",
-    "q1 = machine.qubits[\"q1\"] = Transmon(\n",
-    "    id=\"q1\",\n",
-    "    xy=MWChannel(intermediate_frequency=100e6, opx_output=q1_xy_port.get_reference()),\n",
-    "    resonator=InOutMWChannel(\n",
-    "        intermediate_frequency=100e6,\n",
-    "        opx_output=q1_resonator_out_port.get_reference(),\n",
-    "        opx_input=q1_resonator_in_port.get_reference(),\n",
-    "    ),\n",
-    ")\n",
-    "\n",
-    "# We create another qubit, q2. Here, the resonator channel is omitted for brevity.\n",
-    "q2_xy_mw_output = machine.ports.get_mw_output(\"con1\", 1, 2, create=True)\n",
-    "q2 = machine.qubits[\"q2\"] = Transmon(\n",
-    "    id=\"q2\",\n",
-    "    xy=MWChannel(\n",
-    "        intermediate_frequency=100e6, opx_output=q2_xy_mw_output.get_reference()\n",
-    "    ),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "3abac8b0",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "q1: Transmon\n",
-      "  id: \"q1\"\n",
-      "  macros: QuamDict Empty\n",
-      "  xy: MWChannel\n",
-      "    operations: QuamDict Empty\n",
-      "    id: None\n",
-      "    digital_outputs: QuamDict Empty\n",
-      "    sticky: None\n",
-      "    intermediate_frequency: 100000000.0\n",
-      "    thread: None\n",
-      "    core: None\n",
-      "    LO_frequency: \"#./upconverter_frequency\"\n",
-      "    RF_frequency: \"#./inferred_RF_frequency\"\n",
-      "    opx_output: \"#/ports/mw_outputs/con1/1/1\"\n",
-      "    upconverter: 1\n",
-      "  resonator: InOutMWChannel\n",
-      "    operations: QuamDict Empty\n",
-      "    id: None\n",
-      "    digital_outputs: QuamDict Empty\n",
-      "    sticky: None\n",
-      "    intermediate_frequency: 100000000.0\n",
-      "    thread: None\n",
-      "    core: None\n",
-      "    opx_input: \"#/ports/mw_inputs/con1/1/2\"\n",
-      "    time_of_flight: 24\n",
-      "    smearing: 0\n",
-      "    LO_frequency: \"#./upconverter_frequency\"\n",
-      "    RF_frequency: \"#./inferred_RF_frequency\"\n",
-      "    opx_output: \"#/ports/mw_outputs/con1/1/2\"\n",
-      "    upconverter: 1\n"
-     ]
-    }
-   ],
-   "source": [
-    "# We can view a quick summary of a qubit's configuration:\n",
-    "q1.print_summary()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Qubit pairs\n",
-    "Qubit pairs provide an abstraction for interactions between two qubits.\n",
-    "For example, you might need a specific gate that involves both a control qubit and a target qubit.\n",
-    "Here, we create a pair named \"q1@q2\" which references q1 as control and q2 as target."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "machine.qubit_pairs[\"q1@q2\"] = QubitPair(\n",
-    "    qubit_control=q1.get_reference(), qubit_target=q2.get_reference()\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "c52f2432",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "QubitPair(id='q1@q2', macros={}, qubit_control=Transmon(id='q1', macros={}, xy=MWChannel(operations={}, id=None, digital_outputs={}, sticky=None, intermediate_frequency=100000000.0, thread=None, core=None, LO_frequency=5000000000.0, RF_frequency=5100000000.0, opx_output=MWFEMAnalogOutputPort(controller_id='con1', fem_id=1, port_id=1, band=1, upconverter_frequency=5000000000.0, upconverters=None, delay=0, shareable=False, sampling_rate=1000000000.0, full_scale_power_dbm=-11), upconverter=1), resonator=InOutMWChannel(operations={}, id=None, digital_outputs={}, sticky=None, intermediate_frequency=100000000.0, thread=None, core=None, opx_input=MWFEMAnalogInputPort(controller_id='con1', fem_id=1, port_id=2, band=1, downconverter_frequency=5000000000.0, gain_db=None, sampling_rate=1000000000.0, shareable=False), time_of_flight=24, smearing=0, LO_frequency=5000000000.0, RF_frequency=5100000000.0, opx_output=MWFEMAnalogOutputPort(controller_id='con1', fem_id=1, port_id=2, band=1, upconverter_frequency=5000000000.0, upconverters=None, delay=0, shareable=False, sampling_rate=1000000000.0, full_scale_power_dbm=-11), upconverter=1)), qubit_target=Transmon(id='q2', macros={}, xy=MWChannel(operations={}, id=None, digital_outputs={}, sticky=None, intermediate_frequency=100000000.0, thread=None, core=None, LO_frequency=5000000000.0, RF_frequency=5100000000.0, opx_output=MWFEMAnalogOutputPort(controller_id='con1', fem_id=1, port_id=2, band=1, upconverter_frequency=5000000000.0, upconverters=None, delay=0, shareable=False, sampling_rate=1000000000.0, full_scale_power_dbm=-11), upconverter=1), resonator=None))"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Gate Operations"
       ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# You can then access this pair using:\n",
-    "q1 @ q2"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "91f7eac9",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
-   "source": [
-    "A qubit pair can also be subclassed (similar to how Transmon subclasses Qubit)\n",
-    "if you need extra functionality (e.g., controlling tunable couplers)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6060f96d",
-   "metadata": {},
-   "source": [
-    "## Transforming a Pulse into a Qubit Gate"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f60798a2",
-   "metadata": {},
-   "source": [
-    "In QUAM, a common pattern is to define a pulse (e.g., a square pulse) and then wrap it in a macro class.\n",
-    "This macro can be registered as a gate-level operation, allowing us to write high-level QUA code.\n",
-    "\n",
-    "For example, below we define an \"x180\" pulse (a typical pi rotation around the X axis)\n",
-    "and then create a \"PulseMacro\". This macro is stored in \"q1.macros[\"X\"]\" so we can call it as a gate."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "e39d49d3",
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "# Single QUA script generated at 2025-03-31 19:28:57.397848\n",
-      "# QUA library version: 1.2.2a4\n",
-      "\n",
-      "from qm import CompilerOptionArguments\n",
-      "from qm.qua import *\n",
-      "\n",
-      "with program() as prog:\n",
-      "    play(\"x180\", \"q1.xy\")\n",
-      "\n",
-      "\n",
-      "config = None\n",
-      "\n",
-      "loaded_config = None\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "from quam.components.macro import PulseMacro\n",
-    "\n",
-    "# Define the actual pulse — a simple square envelope with amplitude and duration.\n",
-    "q1.xy.operations[\"x180\"] = pulses.SquarePulse(amplitude=0.2, length=100)\n",
-    "\n",
-    "# Wrap the pulse in a macro so it can be invoked as a logical gate.\n",
-    "q1.macros[\"X\"] = PulseMacro(pulse=q1.xy.operations[\"x180\"].get_reference())\n",
-    "\n",
-    "# Now we can use this macro in a QUA program:\n",
-    "from qm import generate_qua_script, qua\n",
-    "\n",
-    "with qua.program() as prog:\n",
-    "    # Apply the X gate to q1. This calls the macro we just defined.\n",
-    "    q1.apply(\"X\")\n",
-    "\n",
-    "# Print out the generated QUA code to see how it expands.\n",
-    "print(generate_qua_script(prog))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Creating operations"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3afc32c7",
-   "metadata": {},
-   "source": [
-    "To make a macro like \"X\" accessible as a gate-level operation in QUA,\n",
-    "we use an OperationsRegistry. The registry maps gate names (like X) to the correct macro for each qubit."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "42a8d613",
-   "metadata": {
-    "lines_to_end_of_cell_marker": 0,
-    "lines_to_next_cell": 1
-   },
-   "outputs": [],
-   "source": [
-    "from quam.core.operation import OperationsRegistry\n",
-    "\n",
-    "operations_registry = OperationsRegistry()\n",
-    "\n",
-    "@operations_registry.register_operation\n",
-    "# The function name below becomes the gate-level call (e.g., X(q1)).\n",
-    "# Note that internally, it will trigger the macro we assigned to \"q1.macros[\"X\"]\".\n",
-    "def X(qubit: Qubit, **kwargs):\n",
-    "    # Implementation is resolved by the macros attached to the qubit.\n",
-    "    pass"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now calling X(q1) in QUA code triggers the macro q1.macros[\"X\"]."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "c481a483",
-   "metadata": {},
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {
+        "lines_to_next_cell": 2
+      },
+      "source": [
+        "In this guide, we introduce how to build circuit-level QUA programs by focusing on three core concepts:\n",
+        "1. Defining qubits (or qubit pairs)\n",
+        "2. Organizing them within a stateful container (the QUAM)\n",
+        "3. Transforming pulse-level operations into gate-level operations.\n",
+        "\n",
+        "By the end of this tutorial, you will be able to construct a simple program of the form:\n",
+        "```python\n",
+        "with program() as prog:\n",
+        "    X(q1)              # Single-qubit gate\n",
+        "    clifford(q1, 4)    # Clifford gate from a predefined set\n",
+        "    qubit_state = measure(q1)\n",
+        "```\n",
+        "This short snippet will apply specific gate operations to qubit q1 and then measure its state.\n",
+        "\n",
+        "Below is the outline of what we'll cover:\n",
+        "- Defining a custom Transmon qubit class (inheriting from Qubit)\n",
+        "- Creating a stateful QUAM container to hold multiple qubits or qubit pairs\n",
+        "- Registering a qubit pulse macro (e.g., x180) and using it as a gate\n",
+        "- Building custom macros for measurement and more complex gates (Cliffords)\n",
+        "\n",
+        "The goal is to clearly demonstrate the flow from hardware-level pulse definitions all the way to abstract, gate-level instructions in a QUA program."
+      ]
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "# Single QUA script generated at 2025-03-31 19:28:57.412244\n",
-      "# QUA library version: 1.2.2a4\n",
-      "\n",
-      "from qm import CompilerOptionArguments\n",
-      "from qm.qua import *\n",
-      "\n",
-      "with program() as prog:\n",
-      "    play(\"x180\", \"q1.xy\")\n",
-      "\n",
-      "\n",
-      "config = None\n",
-      "\n",
-      "loaded_config = None\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "with qua.program() as prog:\n",
-    "    # This uses the registry to look up the correct macro.\n",
-    "    X(q1)\n",
-    "\n",
-    "print(generate_qua_script(prog))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Creating custom macros"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Often, a gate corresponds to a single pulse, and \"PulseMacro\" is enough. But sometimes, a gate may require\n",
-    "multiple pulses or more complex logic. In that case, we can define a custom macro by subclassing QubitMacro\n",
-    "(or QubitPairMacro if it involves two qubits).\n",
-    "\n",
-    "Below, we create two macros as examples: a \"measure\" macro and a \"clifford\" macro.\n",
-    "These illustrate how to embed logic into your macros and integrate them with the QUAM."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "56dd5f9c",
-   "metadata": {},
-   "source": [
-    "### Measure macro"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "For the measure macro, we define a readout pulse on q1's resonator channel. The macro itself, when called,\n",
-    "plays that pulse, reads I/Q data, and assigns a boolean state based on a threshold."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "q1.resonator.operations[\"readout\"] = pulses.SquareReadoutPulse(\n",
-    "    length=1000, amplitude=0.1, threshold=0.215\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "27da1d83",
-   "metadata": {
-    "lines_to_end_of_cell_marker": 0,
-    "lines_to_next_cell": 1
-   },
-   "outputs": [],
-   "source": [
-    "from quam.components.macro import QubitMacro\n",
-    "from quam.utils.qua_types import QuaVariableBool\n",
-    "\n",
-    "@quam_dataclass\n",
-    "class MeasureMacro(QubitMacro):\n",
-    "    threshold: float\n",
-    "\n",
-    "    def apply(self, **kwargs) -> QuaVariableBool:\n",
-    "        # The macro reads I/Q data from the resonator channel.\n",
-    "        I, Q = self.qubit.resonator.measure(\"readout\")\n",
-    "        # We declare a QUA variable to store the boolean result of thresholding the I value.\n",
-    "        qubit_state = qua.declare(bool)\n",
-    "        qua.assign(qubit_state, I > self.threshold)\n",
-    "        return qubit_state"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "cd34838a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# We attach an instance of this MeasureMacro to our qubit q1.\n",
-    "q1.macros[\"measure\"] = MeasureMacro(threshold=0.215)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we can perform the \"measure\" operation within a QUA program:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "lines_to_end_of_cell_marker": 0,
-    "lines_to_next_cell": 1
-   },
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Defining a Qubit-Level Component"
+      ]
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "# Single QUA script generated at 2025-03-31 19:28:57.445853\n",
-      "# QUA library version: 1.2.2a4\n",
-      "\n",
-      "from qm import CompilerOptionArguments\n",
-      "from qm.qua import *\n",
-      "\n",
-      "with program() as prog:\n",
-      "    v1 = declare(fixed, )\n",
-      "    v2 = declare(fixed, )\n",
-      "    v3 = declare(bool, )\n",
-      "    measure(\"readout\", \"q1.resonator\", dual_demod.full(\"iw1\", \"iw2\", v1), dual_demod.full(\"iw3\", \"iw1\", v2))\n",
-      "    assign(v3, (v1>0.215))\n",
-      "\n",
-      "\n",
-      "config = None\n",
-      "\n",
-      "loaded_config = None\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "with qua.program() as prog:\n",
-    "    qubit_state = q1.apply(\"measure\")  # returns a boolean variable\n",
-    "\n",
-    "print(generate_qua_script(prog))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Similar to the X gate, we can register a generic measure() operation:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
-   "outputs": [],
-   "source": [
-    "@operations_registry.register_operation\n",
-    "def measure(qubit: Qubit, **kwargs) -> QuaVariableBool:\n",
-    "    pass"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This lets us call measure(q1) in a gate-like manner:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "ace53838",
-   "metadata": {},
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We'll begin by importing all the modules we need. Then, we'll define a Transmon class that inherits from Qubit.\n",
+        "In this example, a Transmon has an XY channel and an optional resonator channel for readout.\n",
+        "\n",
+        "Inheriting from Qubit allows us to attach hardware-specific parameters (like channels) and any additional properties\n",
+        "relevant to our hardware setup."
+      ]
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "# Single QUA script generated at 2025-03-31 19:28:57.463403\n",
-      "# QUA library version: 1.2.2a4\n",
-      "\n",
-      "from qm import CompilerOptionArguments\n",
-      "from qm.qua import *\n",
-      "\n",
-      "with program() as prog:\n",
-      "    v1 = declare(fixed, )\n",
-      "    v2 = declare(fixed, )\n",
-      "    v3 = declare(bool, )\n",
-      "    measure(\"readout\", \"q1.resonator\", dual_demod.full(\"iw1\", \"iw2\", v1), dual_demod.full(\"iw3\", \"iw1\", v2))\n",
-      "    assign(v3, (v1>0.215))\n",
-      "\n",
-      "\n",
-      "config = None\n",
-      "\n",
-      "loaded_config = None\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "with qua.program() as prog:\n",
-    "    qubit_state = measure(q1)\n",
-    "\n",
-    "print(generate_qua_script(prog))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9c053dae",
-   "metadata": {},
-   "source": [
-    "### Clifford macro"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Next, we define a single-qubit \"CliffordMacro\". For illustration, we will define a few pulses\n",
-    "that correspond to some of the first five Clifford gates."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
-   "outputs": [],
-   "source": [
-    "# Define additional pulses for x90, x180, y90, y180, etc.\n",
-    "q1.xy.operations[\"x90\"] = pulses.SquarePulse(amplitude=0.1, length=100, axis_angle=0)\n",
-    "q1.xy.operations[\"x180\"] = pulses.SquarePulse(amplitude=0.2, length=100, axis_angle=0)\n",
-    "q1.xy.operations[\"y90\"] = pulses.SquarePulse(amplitude=0.1, length=100, axis_angle=np.pi / 2)\n",
-    "q1.xy.operations[\"y180\"] = pulses.SquarePulse(amplitude=0.2, length=100, axis_angle=np.pi / 2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "da60a094",
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "lines_to_end_of_cell_marker": 0,
+        "lines_to_next_cell": 1
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-03-31 19:28:57,239 - qm - INFO     - Starting session: b8fbbf60-cf4e-4d58-b481-e34d53690c36\n"
+          ]
+        }
+      ],
+      "source": [
+        "from typing import Dict, Optional\n",
+        "import numpy as np\n",
+        "from dataclasses import field\n",
+        "\n",
+        "from quam.components.ports import FEMPortsContainer\n",
+        "from quam.core import QuamRoot, quam_dataclass\n",
+        "from quam.components.quantum_components import Qubit, QubitPair\n",
+        "from quam.components import MWChannel, InOutMWChannel, pulses\n",
+        "\n",
+        "@quam_dataclass\n",
+        "class Transmon(Qubit):\n",
+        "    xy: MWChannel\n",
+        "    resonator: Optional[InOutMWChannel] = None\n",
+        "\n",
+        "@quam_dataclass\n",
+        "class Quam(QuamRoot):\n",
+        "    ports: FEMPortsContainer\n",
+        "    qubits: Dict[str, Qubit] = field(default_factory=dict)\n",
+        "    qubit_pairs: Dict[str, QubitPair] = field(default_factory=dict)"
+      ]
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "# Single QUA script generated at 2025-03-31 19:28:57.498716\n",
-      "# QUA library version: 1.2.2a4\n",
-      "\n",
-      "from qm import CompilerOptionArguments\n",
-      "from qm.qua import *\n",
-      "\n",
-      "with program() as prog:\n",
-      "    v1 = declare(int, value=0)\n",
-      "    with if_((v1==0), unsafe=True):\n",
-      "        wait(25, \"q1.xy\")\n",
-      "    with elif_((v1==1)):\n",
-      "        play(\"x180\", \"q1.xy\")\n",
-      "    with elif_((v1==2)):\n",
-      "        play(\"y180\", \"q1.xy\")\n",
-      "    with elif_((v1==3)):\n",
-      "        play(\"y180\", \"q1.xy\")\n",
-      "        play(\"x180\", \"q1.xy\")\n",
-      "    with elif_((v1==4)):\n",
-      "        play(\"x90\", \"q1.xy\")\n",
-      "        play(\"y90\", \"q1.xy\")\n",
-      "\n",
-      "\n",
-      "config = None\n",
-      "\n",
-      "loaded_config = None\n",
-      "\n",
-      "\n",
-      "\n",
-      "# Single QUA script generated at 2025-03-31 19:28:57.522055\n",
-      "# QUA library version: 1.2.2a4\n",
-      "\n",
-      "from qm import CompilerOptionArguments\n",
-      "from qm.qua import *\n",
-      "\n",
-      "with program() as prog:\n",
-      "    v1 = declare(int, value=0)\n",
-      "    with if_((v1==0), unsafe=True):\n",
-      "        wait(25, \"q1.xy\")\n",
-      "    with elif_((v1==1)):\n",
-      "        play(\"x180\", \"q1.xy\")\n",
-      "    with elif_((v1==2)):\n",
-      "        play(\"y180\", \"q1.xy\")\n",
-      "    with elif_((v1==3)):\n",
-      "        play(\"y180\", \"q1.xy\")\n",
-      "        play(\"x180\", \"q1.xy\")\n",
-      "    with elif_((v1==4)):\n",
-      "        play(\"x90\", \"q1.xy\")\n",
-      "        play(\"y90\", \"q1.xy\")\n",
-      "\n",
-      "\n",
-      "config = None\n",
-      "\n",
-      "loaded_config = None\n",
-      "\n",
-      "\n"
-     ]
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Instantiate QUAM\n",
+        "\n",
+        "QUAM is our top-level container for organizing ports, qubits, and qubit pairs. We start by creating a Quam instance\n",
+        "that includes a FEMPortsContainer, which helps route signals to and from the hardware.\n",
+        "Then we add two Transmon qubits, \"q1\" and \"q2,\" referencing their microwave (MW) channels.\n",
+        "These channels are used for generating pulses that interact with the qubits."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "machine = Quam(ports=FEMPortsContainer())\n",
+        "\n",
+        "## Add qubits\n",
+        "# Here we create the MW output and input ports for q1.\n",
+        "q1_xy_port = machine.ports.get_mw_output(\"con1\", 1, 1, create=True)\n",
+        "q1_resonator_out_port = machine.ports.get_mw_output(\"con1\", 1, 2, create=True)\n",
+        "q1_resonator_in_port = machine.ports.get_mw_input(\"con1\", 1, 2, create=True)\n",
+        "\n",
+        "# Next, we instantiate q1 and specify its XY and resonator channels.\n",
+        "q1 = machine.qubits[\"q1\"] = Transmon(\n",
+        "    id=\"q1\",\n",
+        "    xy=MWChannel(intermediate_frequency=100e6, opx_output=q1_xy_port.get_reference()),\n",
+        "    resonator=InOutMWChannel(\n",
+        "        intermediate_frequency=100e6,\n",
+        "        opx_output=q1_resonator_out_port.get_reference(),\n",
+        "        opx_input=q1_resonator_in_port.get_reference(),\n",
+        "    ),\n",
+        ")\n",
+        "\n",
+        "# We create another qubit, q2. Here, the resonator channel is omitted for brevity.\n",
+        "q2_xy_mw_output = machine.ports.get_mw_output(\"con1\", 1, 2, create=True)\n",
+        "q2 = machine.qubits[\"q2\"] = Transmon(\n",
+        "    id=\"q2\",\n",
+        "    xy=MWChannel(\n",
+        "        intermediate_frequency=100e6, opx_output=q2_xy_mw_output.get_reference()\n",
+        "    ),\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "3abac8b0",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "q1: Transmon\n",
+            "  id: \"q1\"\n",
+            "  macros: QuamDict Empty\n",
+            "  xy: MWChannel\n",
+            "    operations: QuamDict Empty\n",
+            "    id: None\n",
+            "    digital_outputs: QuamDict Empty\n",
+            "    sticky: None\n",
+            "    intermediate_frequency: 100000000.0\n",
+            "    thread: None\n",
+            "    core: None\n",
+            "    LO_frequency: \"#./upconverter_frequency\"\n",
+            "    RF_frequency: \"#./inferred_RF_frequency\"\n",
+            "    opx_output: \"#/ports/mw_outputs/con1/1/1\"\n",
+            "    upconverter: 1\n",
+            "  resonator: InOutMWChannel\n",
+            "    operations: QuamDict Empty\n",
+            "    id: None\n",
+            "    digital_outputs: QuamDict Empty\n",
+            "    sticky: None\n",
+            "    intermediate_frequency: 100000000.0\n",
+            "    thread: None\n",
+            "    core: None\n",
+            "    opx_input: \"#/ports/mw_inputs/con1/1/2\"\n",
+            "    time_of_flight: 140\n",
+            "    smearing: 0\n",
+            "    LO_frequency: \"#./upconverter_frequency\"\n",
+            "    RF_frequency: \"#./inferred_RF_frequency\"\n",
+            "    opx_output: \"#/ports/mw_outputs/con1/1/2\"\n",
+            "    upconverter: 1\n"
+          ]
+        }
+      ],
+      "source": [
+        "# We can view a quick summary of a qubit's configuration:\n",
+        "q1.print_summary()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Qubit pairs\n",
+        "Qubit pairs provide an abstraction for interactions between two qubits.\n",
+        "For example, you might need a specific gate that involves both a control qubit and a target qubit.\n",
+        "Here, we create a pair named \"q1@q2\" which references q1 as control and q2 as target."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "machine.qubit_pairs[\"q1@q2\"] = QubitPair(\n",
+        "    qubit_control=q1.get_reference(), qubit_target=q2.get_reference()\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "id": "c52f2432",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "QubitPair(id='q1@q2', macros={}, qubit_control=Transmon(id='q1', macros={}, xy=MWChannel(operations={}, id=None, digital_outputs={}, sticky=None, intermediate_frequency=100000000.0, thread=None, core=None, LO_frequency=5000000000.0, RF_frequency=5100000000.0, opx_output=MWFEMAnalogOutputPort(controller_id='con1', fem_id=1, port_id=1, band=1, upconverter_frequency=5000000000.0, upconverters=None, delay=0, shareable=False, sampling_rate=1000000000.0, full_scale_power_dbm=-11), upconverter=1), resonator=InOutMWChannel(operations={}, id=None, digital_outputs={}, sticky=None, intermediate_frequency=100000000.0, thread=None, core=None, opx_input=MWFEMAnalogInputPort(controller_id='con1', fem_id=1, port_id=2, band=1, downconverter_frequency=5000000000.0, gain_db=None, sampling_rate=1000000000.0, shareable=False), time_of_flight=140, smearing=0, LO_frequency=5000000000.0, RF_frequency=5100000000.0, opx_output=MWFEMAnalogOutputPort(controller_id='con1', fem_id=1, port_id=2, band=1, upconverter_frequency=5000000000.0, upconverters=None, delay=0, shareable=False, sampling_rate=1000000000.0, full_scale_power_dbm=-11), upconverter=1)), qubit_target=Transmon(id='q2', macros={}, xy=MWChannel(operations={}, id=None, digital_outputs={}, sticky=None, intermediate_frequency=100000000.0, thread=None, core=None, LO_frequency=5000000000.0, RF_frequency=5100000000.0, opx_output=MWFEMAnalogOutputPort(controller_id='con1', fem_id=1, port_id=2, band=1, upconverter_frequency=5000000000.0, upconverters=None, delay=0, shareable=False, sampling_rate=1000000000.0, full_scale_power_dbm=-11), upconverter=1), resonator=None))"
+            ]
+          },
+          "execution_count": 5,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# You can then access this pair using:\n",
+        "q1 @ q2"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "91f7eac9",
+      "metadata": {
+        "lines_to_next_cell": 2
+      },
+      "source": [
+        "A qubit pair can also be subclassed (similar to how Transmon subclasses Qubit)\n",
+        "if you need extra functionality (e.g., controlling tunable couplers)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "6060f96d",
+      "metadata": {},
+      "source": [
+        "## Transforming a Pulse into a Qubit Gate"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "f60798a2",
+      "metadata": {},
+      "source": [
+        "In QUAM, a common pattern is to define a pulse (e.g., a square pulse) and then wrap it in a macro class.\n",
+        "This macro can be registered as a gate-level operation, allowing us to write high-level QUA code.\n",
+        "\n",
+        "For example, below we define an \"x180\" pulse (a typical pi rotation around the X axis)\n",
+        "and then create a \"PulseMacro\". This macro is stored in \"q1.macros[\"X\"]\" so we can call it as a gate."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "id": "e39d49d3",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "# Single QUA script generated at 2025-03-31 19:28:57.397848\n",
+            "# QUA library version: 1.2.2a4\n",
+            "\n",
+            "from qm import CompilerOptionArguments\n",
+            "from qm.qua import *\n",
+            "\n",
+            "with program() as prog:\n",
+            "    play(\"x180\", \"q1.xy\")\n",
+            "\n",
+            "\n",
+            "config = None\n",
+            "\n",
+            "loaded_config = None\n",
+            "\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "from quam.components.macro import PulseMacro\n",
+        "\n",
+        "# Define the actual pulse — a simple square envelope with amplitude and duration.\n",
+        "q1.xy.operations[\"x180\"] = pulses.SquarePulse(amplitude=0.2, length=100)\n",
+        "\n",
+        "# Wrap the pulse in a macro so it can be invoked as a logical gate.\n",
+        "q1.macros[\"X\"] = PulseMacro(pulse=q1.xy.operations[\"x180\"].get_reference())\n",
+        "\n",
+        "# Now we can use this macro in a QUA program:\n",
+        "from qm import generate_qua_script, qua\n",
+        "\n",
+        "with qua.program() as prog:\n",
+        "    # Apply the X gate to q1. This calls the macro we just defined.\n",
+        "    q1.apply(\"X\")\n",
+        "\n",
+        "# Print out the generated QUA code to see how it expands.\n",
+        "print(generate_qua_script(prog))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Creating operations"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "3afc32c7",
+      "metadata": {},
+      "source": [
+        "To make a macro like \"X\" accessible as a gate-level operation in QUA,\n",
+        "we use an OperationsRegistry. The registry maps gate names (like X) to the correct macro for each qubit."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "id": "42a8d613",
+      "metadata": {
+        "lines_to_end_of_cell_marker": 0,
+        "lines_to_next_cell": 1
+      },
+      "outputs": [],
+      "source": [
+        "from quam.core.operation import OperationsRegistry\n",
+        "\n",
+        "operations_registry = OperationsRegistry()\n",
+        "\n",
+        "@operations_registry.register_operation\n",
+        "# The function name below becomes the gate-level call (e.g., X(q1)).\n",
+        "# Note that internally, it will trigger the macro we assigned to \"q1.macros[\"X\"]\".\n",
+        "def X(qubit: Qubit, **kwargs):\n",
+        "    # Implementation is resolved by the macros attached to the qubit.\n",
+        "    pass"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Now calling X(q1) in QUA code triggers the macro q1.macros[\"X\"]."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "id": "c481a483",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "# Single QUA script generated at 2025-03-31 19:28:57.412244\n",
+            "# QUA library version: 1.2.2a4\n",
+            "\n",
+            "from qm import CompilerOptionArguments\n",
+            "from qm.qua import *\n",
+            "\n",
+            "with program() as prog:\n",
+            "    play(\"x180\", \"q1.xy\")\n",
+            "\n",
+            "\n",
+            "config = None\n",
+            "\n",
+            "loaded_config = None\n",
+            "\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "with qua.program() as prog:\n",
+        "    # This uses the registry to look up the correct macro.\n",
+        "    X(q1)\n",
+        "\n",
+        "print(generate_qua_script(prog))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Creating custom macros"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Often, a gate corresponds to a single pulse, and \"PulseMacro\" is enough. But sometimes, a gate may require\n",
+        "multiple pulses or more complex logic. In that case, we can define a custom macro by subclassing QubitMacro\n",
+        "(or QubitPairMacro if it involves two qubits).\n",
+        "\n",
+        "Below, we create two macros as examples: a \"measure\" macro and a \"clifford\" macro.\n",
+        "These illustrate how to embed logic into your macros and integrate them with the QUAM."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "56dd5f9c",
+      "metadata": {},
+      "source": [
+        "### Measure macro"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "For the measure macro, we define a readout pulse on q1's resonator channel. The macro itself, when called,\n",
+        "plays that pulse, reads I/Q data, and assigns a boolean state based on a threshold."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "q1.resonator.operations[\"readout\"] = pulses.SquareReadoutPulse(\n",
+        "    length=1000, amplitude=0.1, threshold=0.215\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "id": "27da1d83",
+      "metadata": {
+        "lines_to_end_of_cell_marker": 0,
+        "lines_to_next_cell": 1
+      },
+      "outputs": [],
+      "source": [
+        "from quam.components.macro import QubitMacro\n",
+        "from quam.utils.qua_types import QuaVariableBool\n",
+        "\n",
+        "@quam_dataclass\n",
+        "class MeasureMacro(QubitMacro):\n",
+        "    threshold: float\n",
+        "\n",
+        "    def apply(self, **kwargs) -> QuaVariableBool:\n",
+        "        # The macro reads I/Q data from the resonator channel.\n",
+        "        I, Q = self.qubit.resonator.measure(\"readout\")\n",
+        "        # We declare a QUA variable to store the boolean result of thresholding the I value.\n",
+        "        qubit_state = qua.declare(bool)\n",
+        "        qua.assign(qubit_state, I > self.threshold)\n",
+        "        return qubit_state"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "id": "cd34838a",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# We attach an instance of this MeasureMacro to our qubit q1.\n",
+        "q1.macros[\"measure\"] = MeasureMacro(threshold=0.215)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Now we can perform the \"measure\" operation within a QUA program:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "lines_to_end_of_cell_marker": 0,
+        "lines_to_next_cell": 1
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "# Single QUA script generated at 2025-03-31 19:28:57.445853\n",
+            "# QUA library version: 1.2.2a4\n",
+            "\n",
+            "from qm import CompilerOptionArguments\n",
+            "from qm.qua import *\n",
+            "\n",
+            "with program() as prog:\n",
+            "    v1 = declare(fixed, )\n",
+            "    v2 = declare(fixed, )\n",
+            "    v3 = declare(bool, )\n",
+            "    measure(\"readout\", \"q1.resonator\", dual_demod.full(\"iw1\", \"iw2\", v1), dual_demod.full(\"iw3\", \"iw1\", v2))\n",
+            "    assign(v3, (v1>0.215))\n",
+            "\n",
+            "\n",
+            "config = None\n",
+            "\n",
+            "loaded_config = None\n",
+            "\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "with qua.program() as prog:\n",
+        "    qubit_state = q1.apply(\"measure\")  # returns a boolean variable\n",
+        "\n",
+        "print(generate_qua_script(prog))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Similar to the X gate, we can register a generic measure() operation:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {
+        "lines_to_next_cell": 1
+      },
+      "outputs": [],
+      "source": [
+        "@operations_registry.register_operation\n",
+        "def measure(qubit: Qubit, **kwargs) -> QuaVariableBool:\n",
+        "    pass"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "This lets us call measure(q1) in a gate-like manner:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "id": "ace53838",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "# Single QUA script generated at 2025-03-31 19:28:57.463403\n",
+            "# QUA library version: 1.2.2a4\n",
+            "\n",
+            "from qm import CompilerOptionArguments\n",
+            "from qm.qua import *\n",
+            "\n",
+            "with program() as prog:\n",
+            "    v1 = declare(fixed, )\n",
+            "    v2 = declare(fixed, )\n",
+            "    v3 = declare(bool, )\n",
+            "    measure(\"readout\", \"q1.resonator\", dual_demod.full(\"iw1\", \"iw2\", v1), dual_demod.full(\"iw3\", \"iw1\", v2))\n",
+            "    assign(v3, (v1>0.215))\n",
+            "\n",
+            "\n",
+            "config = None\n",
+            "\n",
+            "loaded_config = None\n",
+            "\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "with qua.program() as prog:\n",
+        "    qubit_state = measure(q1)\n",
+        "\n",
+        "print(generate_qua_script(prog))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "9c053dae",
+      "metadata": {},
+      "source": [
+        "### Clifford macro"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Next, we define a single-qubit \"CliffordMacro\". For illustration, we will define a few pulses\n",
+        "that correspond to some of the first five Clifford gates."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "lines_to_next_cell": 1
+      },
+      "outputs": [],
+      "source": [
+        "# Define additional pulses for x90, x180, y90, y180, etc.\n",
+        "q1.xy.operations[\"x90\"] = pulses.SquarePulse(amplitude=0.1, length=100, axis_angle=0)\n",
+        "q1.xy.operations[\"x180\"] = pulses.SquarePulse(amplitude=0.2, length=100, axis_angle=0)\n",
+        "q1.xy.operations[\"y90\"] = pulses.SquarePulse(amplitude=0.1, length=100, axis_angle=np.pi / 2)\n",
+        "q1.xy.operations[\"y180\"] = pulses.SquarePulse(amplitude=0.2, length=100, axis_angle=np.pi / 2)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "id": "da60a094",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "# Single QUA script generated at 2025-03-31 19:28:57.498716\n",
+            "# QUA library version: 1.2.2a4\n",
+            "\n",
+            "from qm import CompilerOptionArguments\n",
+            "from qm.qua import *\n",
+            "\n",
+            "with program() as prog:\n",
+            "    v1 = declare(int, value=0)\n",
+            "    with if_((v1==0), unsafe=True):\n",
+            "        wait(25, \"q1.xy\")\n",
+            "    with elif_((v1==1)):\n",
+            "        play(\"x180\", \"q1.xy\")\n",
+            "    with elif_((v1==2)):\n",
+            "        play(\"y180\", \"q1.xy\")\n",
+            "    with elif_((v1==3)):\n",
+            "        play(\"y180\", \"q1.xy\")\n",
+            "        play(\"x180\", \"q1.xy\")\n",
+            "    with elif_((v1==4)):\n",
+            "        play(\"x90\", \"q1.xy\")\n",
+            "        play(\"y90\", \"q1.xy\")\n",
+            "\n",
+            "\n",
+            "config = None\n",
+            "\n",
+            "loaded_config = None\n",
+            "\n",
+            "\n",
+            "\n",
+            "# Single QUA script generated at 2025-03-31 19:28:57.522055\n",
+            "# QUA library version: 1.2.2a4\n",
+            "\n",
+            "from qm import CompilerOptionArguments\n",
+            "from qm.qua import *\n",
+            "\n",
+            "with program() as prog:\n",
+            "    v1 = declare(int, value=0)\n",
+            "    with if_((v1==0), unsafe=True):\n",
+            "        wait(25, \"q1.xy\")\n",
+            "    with elif_((v1==1)):\n",
+            "        play(\"x180\", \"q1.xy\")\n",
+            "    with elif_((v1==2)):\n",
+            "        play(\"y180\", \"q1.xy\")\n",
+            "    with elif_((v1==3)):\n",
+            "        play(\"y180\", \"q1.xy\")\n",
+            "        play(\"x180\", \"q1.xy\")\n",
+            "    with elif_((v1==4)):\n",
+            "        play(\"x90\", \"q1.xy\")\n",
+            "        play(\"y90\", \"q1.xy\")\n",
+            "\n",
+            "\n",
+            "config = None\n",
+            "\n",
+            "loaded_config = None\n",
+            "\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "@quam_dataclass\n",
+        "class CliffordMacro(QubitMacro):\n",
+        "    def apply(self, clifford_idx: int, **kwargs):\n",
+        "        # We use a QUA switch_ statement to choose which pulses to play in real time.\n",
+        "        with qua.switch_(clifford_idx, unsafe=True):\n",
+        "            with qua.case_(0):\n",
+        "                # Identity operation: do nothing except wait to preserve timing.\n",
+        "                wait_duration = self.qubit.xy.operations[\"x180\"].length // 4\n",
+        "                self.qubit.xy.wait(wait_duration)\n",
+        "            with qua.case_(1):\n",
+        "                self.qubit.xy.play(\"x180\")\n",
+        "            with qua.case_(2):\n",
+        "                self.qubit.xy.play(\"y180\")\n",
+        "            with qua.case_(3):\n",
+        "                self.qubit.xy.play(\"y180\")\n",
+        "                self.qubit.xy.play(\"x180\")\n",
+        "            with qua.case_(4):\n",
+        "                # This is a composite gate (x90 followed by y90)\n",
+        "                self.qubit.xy.play(\"x90\")\n",
+        "                self.qubit.xy.play(\"y90\")\n",
+        "            # You can continue defining more Clifford cases here...\n",
+        "\n",
+        "# Attach the macro to q1\n",
+        "q1.macros[\"clifford\"] = CliffordMacro()\n",
+        "\n",
+        "# We can now call this macro using q1.apply(\"clifford\", clifford_idx):\n",
+        "\n",
+        "with qua.program() as prog:\n",
+        "    clifford_idx = qua.declare(int, 0)\n",
+        "    q1.apply(\"clifford\", clifford_idx)\n",
+        "\n",
+        "print(generate_qua_script(prog))\n",
+        "\n",
+        "# As before, we register a qubit-generic function:\n",
+        "\n",
+        "@operations_registry.register_operation\n",
+        "def clifford(qubit: Qubit, clifford_idx: int, **kwargs):\n",
+        "    pass\n",
+        "\n",
+        "# Now we can call clifford(q1, clifford_idx) in our QUA program:\n",
+        "\n",
+        "with qua.program() as prog:\n",
+        "    clifford_idx = qua.declare(int, 0)\n",
+        "    clifford(q1, clifford_idx)\n",
+        "\n",
+        "print(generate_qua_script(prog))"
+      ]
     }
-   ],
-   "source": [
-    "@quam_dataclass\n",
-    "class CliffordMacro(QubitMacro):\n",
-    "    def apply(self, clifford_idx: int, **kwargs):\n",
-    "        # We use a QUA switch_ statement to choose which pulses to play in real time.\n",
-    "        with qua.switch_(clifford_idx, unsafe=True):\n",
-    "            with qua.case_(0):\n",
-    "                # Identity operation: do nothing except wait to preserve timing.\n",
-    "                wait_duration = self.qubit.xy.operations[\"x180\"].length // 4\n",
-    "                self.qubit.xy.wait(wait_duration)\n",
-    "            with qua.case_(1):\n",
-    "                self.qubit.xy.play(\"x180\")\n",
-    "            with qua.case_(2):\n",
-    "                self.qubit.xy.play(\"y180\")\n",
-    "            with qua.case_(3):\n",
-    "                self.qubit.xy.play(\"y180\")\n",
-    "                self.qubit.xy.play(\"x180\")\n",
-    "            with qua.case_(4):\n",
-    "                # This is a composite gate (x90 followed by y90)\n",
-    "                self.qubit.xy.play(\"x90\")\n",
-    "                self.qubit.xy.play(\"y90\")\n",
-    "            # You can continue defining more Clifford cases here...\n",
-    "\n",
-    "# Attach the macro to q1\n",
-    "q1.macros[\"clifford\"] = CliffordMacro()\n",
-    "\n",
-    "# We can now call this macro using q1.apply(\"clifford\", clifford_idx):\n",
-    "\n",
-    "with qua.program() as prog:\n",
-    "    clifford_idx = qua.declare(int, 0)\n",
-    "    q1.apply(\"clifford\", clifford_idx)\n",
-    "\n",
-    "print(generate_qua_script(prog))\n",
-    "\n",
-    "# As before, we register a qubit-generic function:\n",
-    "\n",
-    "@operations_registry.register_operation\n",
-    "def clifford(qubit: Qubit, clifford_idx: int, **kwargs):\n",
-    "    pass\n",
-    "\n",
-    "# Now we can call clifford(q1, clifford_idx) in our QUA program:\n",
-    "\n",
-    "with qua.program() as prog:\n",
-    "    clifford_idx = qua.declare(int, 0)\n",
-    "    clifford(q1, clifford_idx)\n",
-    "\n",
-    "print(generate_qua_script(prog))"
-   ]
-  }
- ],
- "metadata": {
-  "jupytext": {
-   "formats": "ipynb,py"
+  ],
+  "metadata": {
+    "jupytext": {
+      "formats": "ipynb,py"
+    },
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.11"
+    }
   },
-  "kernelspec": {
-   "display_name": ".venv",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.11"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+  "nbformat": 4,
+  "nbformat_minor": 2
 }

--- a/docs/examples/QuAM features.ipynb
+++ b/docs/examples/QuAM features.ipynb
@@ -1,666 +1,666 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "# QUAM Demonstration"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 2,
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "2025-04-07 18:10:13,680 - qm - INFO     - Starting session: 86eda8f7-6776-441f-89f4-5449acb3bd99\n"
-                    ]
-                }
-            ],
-            "source": [
-                "import json\n",
-                "from quam.components import *\n",
-                "from quam.examples.superconducting_qubits import *\n",
-                "\n",
-                "from pathlib import Path\n",
-                "root_folder = Path(\"./output\")\n",
-                "root_folder.mkdir(exist_ok=True)\n",
-                "for key in [\"basic\", \"referenced\", \"referenced_multifile\"]:\n",
-                "    (root_folder / key).mkdir(exist_ok=True)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## Creating QUAM from Scratch"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "The user defines his own QuAM by inheriting from `QuamRoot` (see `components/quam.py`).\n",
-                "Once defined, it can be instantiated as follows:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 3,
-            "metadata": {},
-            "outputs": [
-                {
-                    "ename": "NameError",
-                    "evalue": "name 'Quam' is not defined",
-                    "output_type": "error",
-                    "traceback": [
-                        "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-                        "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-                        "Cell \u001b[0;32mIn[3], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m machine \u001b[38;5;241m=\u001b[39m \u001b[43mQuam\u001b[49m()\n\u001b[1;32m      2\u001b[0m machine\n",
-                        "\u001b[0;31mNameError\u001b[0m: name 'Quam' is not defined"
-                    ]
-                }
-            ],
-            "source": [
-                "machine = Quam()\n",
-                "machine"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "We see that five attributes are defined in quam, all empty so far. We can begin populating it with different `QuamComponent`s"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 3,
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "QuAM:\n",
-                        "  qubits: QuamDict\n",
-                        "    q0: Transmon\n",
-                        "      id: 0\n",
-                        "      xy: IQChannel\n",
-                        "        operations: QuamDict Empty\n",
-                        "        id: None\n",
-                        "        digital_outputs: QuamDict Empty\n",
-                        "        opx_output_I: ('con1', 3)\n",
-                        "        opx_output_Q: ('con1', 4)\n",
-                        "        opx_output_offset_I: None\n",
-                        "        opx_output_offset_Q: None\n",
-                        "        frequency_converter_up: FrequencyConverter\n",
-                        "          local_oscillator: LocalOscillator\n",
-                        "            frequency: 6000000000.0\n",
-                        "            power: 10\n",
-                        "          mixer: Mixer\n",
-                        "            local_oscillator_frequency: \"#../local_oscillator/frequency\"\n",
-                        "            intermediate_frequency: \"#../../intermediate_frequency\"\n",
-                        "            correction_gain: 0\n",
-                        "            correction_phase: 0\n",
-                        "          gain: None\n",
-                        "        intermediate_frequency: 100000000.0\n",
-                        "      z: SingleChannel\n",
-                        "        operations: QuamDict Empty\n",
-                        "        id: None\n",
-                        "        digital_outputs: QuamDict Empty\n",
-                        "        opx_output: ('con1', 5)\n",
-                        "        filter_fir_taps: None\n",
-                        "        filter_iir_taps: None\n",
-                        "        opx_output_offset: None\n",
-                        "        intermediate_frequency: None\n",
-                        "      resonator: InOutIQChannel\n",
-                        "        operations: QuamDict Empty\n",
-                        "        id: 0\n",
-                        "        digital_outputs: QuamDict Empty\n",
-                        "        opx_output_I: ('con1', 1)\n",
-                        "        opx_output_Q: ('con1', 2)\n",
-                        "        opx_output_offset_I: None\n",
-                        "        opx_output_offset_Q: None\n",
-                        "        frequency_converter_up: FrequencyConverter\n",
-                        "          local_oscillator: LocalOscillator\n",
-                        "            frequency: 6000000000.0\n",
-                        "            power: 10\n",
-                        "          mixer: Mixer\n",
-                        "            local_oscillator_frequency: \"#../local_oscillator/frequency\"\n",
-                        "            intermediate_frequency: \"#../../intermediate_frequency\"\n",
-                        "            correction_gain: 0\n",
-                        "            correction_phase: 0\n",
-                        "          gain: None\n",
-                        "        intermediate_frequency: 0.0\n",
-                        "        opx_input_I: ('con1', 1)\n",
-                        "        opx_input_Q: ('con1', 2)\n",
-                        "        time_of_flight: 24\n",
-                        "        smearing: 0\n",
-                        "        opx_input_offset_I: None\n",
-                        "        opx_input_offset_Q: None\n",
-                        "        input_gain: None\n",
-                        "        frequency_converter_down: None\n",
-                        "    q1: Transmon\n",
-                        "      id: 1\n",
-                        "      xy: IQChannel\n",
-                        "        operations: QuamDict Empty\n",
-                        "        id: None\n",
-                        "        digital_outputs: QuamDict Empty\n",
-                        "        opx_output_I: ('con1', 6)\n",
-                        "        opx_output_Q: ('con1', 7)\n",
-                        "        opx_output_offset_I: None\n",
-                        "        opx_output_offset_Q: None\n",
-                        "        frequency_converter_up: FrequencyConverter\n",
-                        "          local_oscillator: LocalOscillator\n",
-                        "            frequency: 6000000000.0\n",
-                        "            power: 10\n",
-                        "          mixer: Mixer\n",
-                        "            local_oscillator_frequency: \"#../local_oscillator/frequency\"\n",
-                        "            intermediate_frequency: \"#../../intermediate_frequency\"\n",
-                        "            correction_gain: 0\n",
-                        "            correction_phase: 0\n",
-                        "          gain: None\n",
-                        "        intermediate_frequency: 100000000.0\n",
-                        "      z: SingleChannel\n",
-                        "        operations: QuamDict Empty\n",
-                        "        id: None\n",
-                        "        digital_outputs: QuamDict Empty\n",
-                        "        opx_output: ('con1', 8)\n",
-                        "        filter_fir_taps: None\n",
-                        "        filter_iir_taps: None\n",
-                        "        opx_output_offset: None\n",
-                        "        intermediate_frequency: None\n",
-                        "      resonator: InOutIQChannel\n",
-                        "        operations: QuamDict Empty\n",
-                        "        id: 1\n",
-                        "        digital_outputs: QuamDict Empty\n",
-                        "        opx_output_I: ('con1', 4)\n",
-                        "        opx_output_Q: ('con1', 5)\n",
-                        "        opx_output_offset_I: None\n",
-                        "        opx_output_offset_Q: None\n",
-                        "        frequency_converter_up: FrequencyConverter\n",
-                        "          local_oscillator: LocalOscillator\n",
-                        "            frequency: 6000000000.0\n",
-                        "            power: 10\n",
-                        "          mixer: Mixer\n",
-                        "            local_oscillator_frequency: \"#../local_oscillator/frequency\"\n",
-                        "            intermediate_frequency: \"#../../intermediate_frequency\"\n",
-                        "            correction_gain: 0\n",
-                        "            correction_phase: 0\n",
-                        "          gain: None\n",
-                        "        intermediate_frequency: 0.0\n",
-                        "        opx_input_I: ('con1', 1)\n",
-                        "        opx_input_Q: ('con1', 2)\n",
-                        "        time_of_flight: 24\n",
-                        "        smearing: 0\n",
-                        "        opx_input_offset_I: None\n",
-                        "        opx_input_offset_Q: None\n",
-                        "        input_gain: None\n",
-                        "        frequency_converter_down: None\n",
-                        "  wiring: QuamDict Empty\n"
-                    ]
-                }
-            ],
-            "source": [
-                "num_qubits = 2\n",
-                "for idx in range(num_qubits):\n",
-                "    # Create qubit components\n",
-                "    transmon = Transmon(\n",
-                "        id=idx,\n",
-                "        xy=IQChannel(\n",
-                "            opx_output_I=(\"con1\", 3 * idx + 3),\n",
-                "            opx_output_Q=(\"con1\", 3 * idx + 4),\n",
-                "            frequency_converter_up=FrequencyConverter(\n",
-                "                mixer=Mixer(),\n",
-                "                local_oscillator=LocalOscillator(power=10, frequency=6e9),\n",
-                "            ),\n",
-                "            intermediate_frequency=100e6,\n",
-                "        ),\n",
-                "        z=SingleChannel(opx_output=(\"con1\", 3 * idx + 5)),\n",
-                "    )\n",
-                "    machine.qubits[transmon.name] = transmon\n",
-                "    readout_resonator = InOutIQChannel(\n",
-                "        id=idx,\n",
-                "        opx_output_I=(\"con1\", 3 * idx + 1),\n",
-                "        opx_output_Q=(\"con1\", 3 * idx + 2),\n",
-                "        opx_input_I=(\"con1\", 1),\n",
-                "        opx_input_Q=(\"con1\", 2,),\n",
-                "        frequency_converter_up=FrequencyConverter(\n",
-                "            mixer=Mixer(), local_oscillator=LocalOscillator(power=10, frequency=6e9)\n",
-                "        ),\n",
-                "    )\n",
-                "    transmon.resonator = readout_resonator\n",
-                "\n",
-                "machine.print_summary()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "A summary of QUAM can be shown using `machine.print_summary()`"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## Saving and Loading QUAM"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "We can then save quam to a json file:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 4,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "machine.save(root_folder / \"basic\" / \"state.json\")"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "Finally, we can also load quam from the same json file"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 5,
-            "metadata": {},
-            "outputs": [
-                {
-                    "ename": "NameError",
-                    "evalue": "name 'Quam' is not defined",
-                    "output_type": "error",
-                    "traceback": [
-                        "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-                        "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-                        "Cell \u001b[0;32mIn[5], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m loaded_quam \u001b[38;5;241m=\u001b[39m \u001b[43mQuam\u001b[49m\u001b[38;5;241m.\u001b[39mload(root_folder \u001b[38;5;241m/\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbasic\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m/\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstate.json\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-                        "\u001b[0;31mNameError\u001b[0m: name 'Quam' is not defined"
-                    ]
-                }
-            ],
-            "source": [
-                "loaded_quam = Quam.load(root_folder / \"basic\" / \"state.json\")"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "Importantly, the `state.json` file only describes how QuAM is structured, and how the different QuAM components should be initialized. The components themselves are defined in their respective classes."
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## Generating QUA Configuration"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "We can also generate the qua config from quam. This recursively calls `QuamComponent.apply_to_config()` on all quam components."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 6,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "qua_config = machine.generate_config()\n",
-                "json.dump(qua_config, open(root_folder / \"basic\" / \"qua_config.json\", \"w\"), indent=2)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 7,
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "text/plain": [
-                            "PosixPath('output/basic/qua_config.json')"
-                        ]
-                    },
-                    "execution_count": 7,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "root_folder / \"basic\" / \"qua_config.json\""
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## QUAM Using References"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "QuAM allows values to reference another part of QuAM by setting its value to a string starting with a colon: `\"#/path/to/referenced/value\"`.\n",
-                "\n",
-                "As an example why this is useful, we previously hardcoded all output ports. However, grouping everything at a top-level `\"wiring\"`` makes more sense, so we can have all output ports reference to it.\n",
-                "\n",
-                "Below we also add several more references"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 8,
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "QuAM:\n",
-                        "  qubits: QuamDict\n",
-                        "    q0: Transmon\n",
-                        "      id: 0\n",
-                        "      xy: IQChannel\n",
-                        "        operations: QuamDict Empty\n",
-                        "        id: None\n",
-                        "        digital_outputs: QuamDict Empty\n",
-                        "        opx_output_I: \"#/wiring/qubits/q0/port_I\"\n",
-                        "        opx_output_Q: \"#/wiring/qubits/q0/port_Q\"\n",
-                        "        opx_output_offset_I: None\n",
-                        "        opx_output_offset_Q: None\n",
-                        "        frequency_converter_up: FrequencyConverter\n",
-                        "          local_oscillator: LocalOscillator\n",
-                        "            frequency: 6000000000.0\n",
-                        "            power: 10\n",
-                        "          mixer: Mixer\n",
-                        "            local_oscillator_frequency: \"#../local_oscillator/frequency\"\n",
-                        "            intermediate_frequency: \"#../../intermediate_frequency\"\n",
-                        "            correction_gain: 0\n",
-                        "            correction_phase: 0\n",
-                        "          gain: None\n",
-                        "        intermediate_frequency: 100000000.0\n",
-                        "      z: SingleChannel\n",
-                        "        operations: QuamDict Empty\n",
-                        "        id: None\n",
-                        "        digital_outputs: QuamDict Empty\n",
-                        "        opx_output: \"#/wiring/qubits/q0/port_Z\"\n",
-                        "        filter_fir_taps: None\n",
-                        "        filter_iir_taps: None\n",
-                        "        opx_output_offset: None\n",
-                        "        intermediate_frequency: None\n",
-                        "      resonator: InOutIQChannel\n",
-                        "        operations: QuamDict Empty\n",
-                        "        id: 0\n",
-                        "        digital_outputs: QuamDict Empty\n",
-                        "        opx_output_I: \"#/wiring/feedline/opx_output_I\"\n",
-                        "        opx_output_Q: \"#/wiring/feedline/opx_output_Q\"\n",
-                        "        opx_output_offset_I: None\n",
-                        "        opx_output_offset_Q: None\n",
-                        "        frequency_converter_up: FrequencyConverter\n",
-                        "          local_oscillator: LocalOscillator\n",
-                        "            frequency: 6000000000.0\n",
-                        "            power: 10\n",
-                        "          mixer: Mixer\n",
-                        "            local_oscillator_frequency: \"#../local_oscillator/frequency\"\n",
-                        "            intermediate_frequency: \"#../../intermediate_frequency\"\n",
-                        "            correction_gain: 0\n",
-                        "            correction_phase: 0\n",
-                        "          gain: None\n",
-                        "        intermediate_frequency: 0.0\n",
-                        "        opx_input_I: \"#/wiring/feedline/opx_input_I\"\n",
-                        "        opx_input_Q: \"#/wiring/feedline/opx_input_Q\"\n",
-                        "        time_of_flight: 24\n",
-                        "        smearing: 0\n",
-                        "        opx_input_offset_I: None\n",
-                        "        opx_input_offset_Q: None\n",
-                        "        input_gain: None\n",
-                        "        frequency_converter_down: None\n",
-                        "    q1: Transmon\n",
-                        "      id: 1\n",
-                        "      xy: IQChannel\n",
-                        "        operations: QuamDict Empty\n",
-                        "        id: None\n",
-                        "        digital_outputs: QuamDict Empty\n",
-                        "        opx_output_I: \"#/wiring/qubits/q1/port_I\"\n",
-                        "        opx_output_Q: \"#/wiring/qubits/q1/port_Q\"\n",
-                        "        opx_output_offset_I: None\n",
-                        "        opx_output_offset_Q: None\n",
-                        "        frequency_converter_up: FrequencyConverter\n",
-                        "          local_oscillator: LocalOscillator\n",
-                        "            frequency: 6000000000.0\n",
-                        "            power: 10\n",
-                        "          mixer: Mixer\n",
-                        "            local_oscillator_frequency: \"#../local_oscillator/frequency\"\n",
-                        "            intermediate_frequency: \"#../../intermediate_frequency\"\n",
-                        "            correction_gain: 0\n",
-                        "            correction_phase: 0\n",
-                        "          gain: None\n",
-                        "        intermediate_frequency: 100000000.0\n",
-                        "      z: SingleChannel\n",
-                        "        operations: QuamDict Empty\n",
-                        "        id: None\n",
-                        "        digital_outputs: QuamDict Empty\n",
-                        "        opx_output: \"#/wiring/qubits/q1/port_Z\"\n",
-                        "        filter_fir_taps: None\n",
-                        "        filter_iir_taps: None\n",
-                        "        opx_output_offset: None\n",
-                        "        intermediate_frequency: None\n",
-                        "      resonator: InOutIQChannel\n",
-                        "        operations: QuamDict Empty\n",
-                        "        id: 1\n",
-                        "        digital_outputs: QuamDict Empty\n",
-                        "        opx_output_I: \"#/wiring/feedline/opx_output_I\"\n",
-                        "        opx_output_Q: \"#/wiring/feedline/opx_output_Q\"\n",
-                        "        opx_output_offset_I: None\n",
-                        "        opx_output_offset_Q: None\n",
-                        "        frequency_converter_up: FrequencyConverter\n",
-                        "          local_oscillator: LocalOscillator\n",
-                        "            frequency: 6000000000.0\n",
-                        "            power: 10\n",
-                        "          mixer: Mixer\n",
-                        "            local_oscillator_frequency: \"#../local_oscillator/frequency\"\n",
-                        "            intermediate_frequency: \"#../../intermediate_frequency\"\n",
-                        "            correction_gain: 0\n",
-                        "            correction_phase: 0\n",
-                        "          gain: None\n",
-                        "        intermediate_frequency: 0.0\n",
-                        "        opx_input_I: \"#/wiring/feedline/opx_input_I\"\n",
-                        "        opx_input_Q: \"#/wiring/feedline/opx_input_Q\"\n",
-                        "        time_of_flight: 24\n",
-                        "        smearing: 0\n",
-                        "        opx_input_offset_I: None\n",
-                        "        opx_input_offset_Q: None\n",
-                        "        input_gain: None\n",
-                        "        frequency_converter_down: None\n",
-                        "  wiring: QuamDict\n",
-                        "    qubits: QuamDict\n",
-                        "      q0: QuamDict\n",
-                        "        port_I: ('con1', 3)\n",
-                        "        port_Q: ('con1', 4)\n",
-                        "        port_Z: ('con1', 5)\n",
-                        "      q1: QuamDict\n",
-                        "        port_I: ('con1', 6)\n",
-                        "        port_Q: ('con1', 7)\n",
-                        "        port_Z: ('con1', 8)\n",
-                        "    feedline: QuamDict\n",
-                        "      opx_output_I: ('con1', 1)\n",
-                        "      opx_output_Q: ('con1', 2)\n",
-                        "      opx_input_I: ('con1', 1)\n",
-                        "      opx_input_Q: ('con1', 2)\n"
-                    ]
-                }
-            ],
-            "source": [
-                "num_qubits = 2\n",
-                "machine = Quam()\n",
-                "machine.wiring = {\n",
-                "    \"qubits\": {\n",
-                "        f\"q{idx}\": {\n",
-                "            \"port_I\": (\"con1\", 3 * idx + 3),\n",
-                "            \"port_Q\": (\"con1\", 3 * idx + 4),\n",
-                "            \"port_Z\": (\"con1\", 3 * idx + 5),\n",
-                "        }\n",
-                "        for idx in range(num_qubits)\n",
-                "    },\n",
-                "    \"feedline\": {\n",
-                "        \"opx_output_I\": (\"con1\", 1),\n",
-                "        \"opx_output_Q\": (\"con1\", 2),\n",
-                "        \"opx_input_I\": (\"con1\", 1),\n",
-                "        \"opx_input_Q\": (\"con1\", 2),\n",
-                "    },\n",
-                "}\n",
-                "\n",
-                "for idx in range(num_qubits):\n",
-                "    # Create qubit components\n",
-                "    transmon = Transmon(\n",
-                "        id=idx,\n",
-                "        xy=IQChannel(\n",
-                "            opx_output_I=f\"#/wiring/qubits/q{idx}/port_I\",\n",
-                "            opx_output_Q=f\"#/wiring/qubits/q{idx}/port_Q\",\n",
-                "            frequency_converter_up=FrequencyConverter(\n",
-                "                mixer=Mixer(),\n",
-                "                local_oscillator=LocalOscillator(power=10, frequency=6e9),\n",
-                "            ),\n",
-                "            intermediate_frequency=100e6,\n",
-                "        ),\n",
-                "        z=SingleChannel(opx_output=f\"#/wiring/qubits/q{idx}/port_Z\"),\n",
-                "    )\n",
-                "    machine.qubits[transmon.name] = transmon\n",
-                "    readout_resonator = InOutIQChannel(\n",
-                "        id=idx,\n",
-                "        opx_output_I=\"#/wiring/feedline/opx_output_I\",\n",
-                "        opx_output_Q=\"#/wiring/feedline/opx_output_Q\",\n",
-                "        opx_input_I=\"#/wiring/feedline/opx_input_I\",\n",
-                "        opx_input_Q=\"#/wiring/feedline/opx_input_Q\",\n",
-                "        frequency_converter_up=FrequencyConverter(\n",
-                "            mixer=Mixer(), local_oscillator=LocalOscillator(power=10, frequency=6e9)\n",
-                "        ),\n",
-                "    )\n",
-                "    transmon.resonator = readout_resonator\n",
-                "\n",
-                "machine.print_summary()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "We again save quam and the QUA config. The QUA config is identical to previous, but QUAM has changed significantly"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 9,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "machine.save(root_folder / \"referenced\" / \"state.json\")"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 10,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "qua_config = machine.generate_config()\n",
-                "json.dump(qua_config, open(root_folder / \"referenced\" / \"qua_config.json\", \"w\"), indent=2)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## Separating QUAM into Multiple Files"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "Finally, we can also separate parts of QuAM to be placed into a separate file.\n",
-                "This can be especially useful when combined with referencing because we can now have a separate file dedicated to the wiring of the experiment.\n",
-                "\n",
-                "Here we point quam to a folder instead of a json file, and we specify that `\"wiring\"` should go to a separate `wiring.json` file in that folder:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 11,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "machine.save(root_folder / \"referenced_multifile\" / \"quam\", content_mapping={\"wiring.json\": [\"wiring\"]})"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "It can subseuently be loaded as usual"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 12,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "machine = Quam.load(root_folder / \"referenced_multifile\" / \"quam\")"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "Separating QUAM into multiple files allows the user to revert back to a previous QUAM but keep some parts the same.\n",
-                "For example, the user may want to revert all experimental settings, but the wiring of the setup should of course not change."
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": []
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": ".venv",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.11.11"
-        },
-        "orig_nbformat": 4
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# QUAM Demonstration"
+      ]
     },
-    "nbformat": 4,
-    "nbformat_minor": 2
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-04-07 18:10:13,680 - qm - INFO     - Starting session: 86eda8f7-6776-441f-89f4-5449acb3bd99\n"
+          ]
+        }
+      ],
+      "source": [
+        "import json\n",
+        "from quam.components import *\n",
+        "from quam.examples.superconducting_qubits import *\n",
+        "\n",
+        "from pathlib import Path\n",
+        "root_folder = Path(\"./output\")\n",
+        "root_folder.mkdir(exist_ok=True)\n",
+        "for key in [\"basic\", \"referenced\", \"referenced_multifile\"]:\n",
+        "    (root_folder / key).mkdir(exist_ok=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Creating QUAM from Scratch"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "The user defines his own QuAM by inheriting from `QuamRoot` (see `components/quam.py`).\n",
+        "Once defined, it can be instantiated as follows:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [
+        {
+          "ename": "NameError",
+          "evalue": "name 'Quam' is not defined",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+            "Cell \u001b[0;32mIn[3], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m machine \u001b[38;5;241m=\u001b[39m \u001b[43mQuam\u001b[49m()\n\u001b[1;32m      2\u001b[0m machine\n",
+            "\u001b[0;31mNameError\u001b[0m: name 'Quam' is not defined"
+          ]
+        }
+      ],
+      "source": [
+        "machine = Quam()\n",
+        "machine"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We see that five attributes are defined in quam, all empty so far. We can begin populating it with different `QuamComponent`s"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "QuAM:\n",
+            "  qubits: QuamDict\n",
+            "    q0: Transmon\n",
+            "      id: 0\n",
+            "      xy: IQChannel\n",
+            "        operations: QuamDict Empty\n",
+            "        id: None\n",
+            "        digital_outputs: QuamDict Empty\n",
+            "        opx_output_I: ('con1', 3)\n",
+            "        opx_output_Q: ('con1', 4)\n",
+            "        opx_output_offset_I: None\n",
+            "        opx_output_offset_Q: None\n",
+            "        frequency_converter_up: FrequencyConverter\n",
+            "          local_oscillator: LocalOscillator\n",
+            "            frequency: 6000000000.0\n",
+            "            power: 10\n",
+            "          mixer: Mixer\n",
+            "            local_oscillator_frequency: \"#../local_oscillator/frequency\"\n",
+            "            intermediate_frequency: \"#../../intermediate_frequency\"\n",
+            "            correction_gain: 0\n",
+            "            correction_phase: 0\n",
+            "          gain: None\n",
+            "        intermediate_frequency: 100000000.0\n",
+            "      z: SingleChannel\n",
+            "        operations: QuamDict Empty\n",
+            "        id: None\n",
+            "        digital_outputs: QuamDict Empty\n",
+            "        opx_output: ('con1', 5)\n",
+            "        filter_fir_taps: None\n",
+            "        filter_iir_taps: None\n",
+            "        opx_output_offset: None\n",
+            "        intermediate_frequency: None\n",
+            "      resonator: InOutIQChannel\n",
+            "        operations: QuamDict Empty\n",
+            "        id: 0\n",
+            "        digital_outputs: QuamDict Empty\n",
+            "        opx_output_I: ('con1', 1)\n",
+            "        opx_output_Q: ('con1', 2)\n",
+            "        opx_output_offset_I: None\n",
+            "        opx_output_offset_Q: None\n",
+            "        frequency_converter_up: FrequencyConverter\n",
+            "          local_oscillator: LocalOscillator\n",
+            "            frequency: 6000000000.0\n",
+            "            power: 10\n",
+            "          mixer: Mixer\n",
+            "            local_oscillator_frequency: \"#../local_oscillator/frequency\"\n",
+            "            intermediate_frequency: \"#../../intermediate_frequency\"\n",
+            "            correction_gain: 0\n",
+            "            correction_phase: 0\n",
+            "          gain: None\n",
+            "        intermediate_frequency: 0.0\n",
+            "        opx_input_I: ('con1', 1)\n",
+            "        opx_input_Q: ('con1', 2)\n",
+            "        time_of_flight: 140\n",
+            "        smearing: 0\n",
+            "        opx_input_offset_I: None\n",
+            "        opx_input_offset_Q: None\n",
+            "        input_gain: None\n",
+            "        frequency_converter_down: None\n",
+            "    q1: Transmon\n",
+            "      id: 1\n",
+            "      xy: IQChannel\n",
+            "        operations: QuamDict Empty\n",
+            "        id: None\n",
+            "        digital_outputs: QuamDict Empty\n",
+            "        opx_output_I: ('con1', 6)\n",
+            "        opx_output_Q: ('con1', 7)\n",
+            "        opx_output_offset_I: None\n",
+            "        opx_output_offset_Q: None\n",
+            "        frequency_converter_up: FrequencyConverter\n",
+            "          local_oscillator: LocalOscillator\n",
+            "            frequency: 6000000000.0\n",
+            "            power: 10\n",
+            "          mixer: Mixer\n",
+            "            local_oscillator_frequency: \"#../local_oscillator/frequency\"\n",
+            "            intermediate_frequency: \"#../../intermediate_frequency\"\n",
+            "            correction_gain: 0\n",
+            "            correction_phase: 0\n",
+            "          gain: None\n",
+            "        intermediate_frequency: 100000000.0\n",
+            "      z: SingleChannel\n",
+            "        operations: QuamDict Empty\n",
+            "        id: None\n",
+            "        digital_outputs: QuamDict Empty\n",
+            "        opx_output: ('con1', 8)\n",
+            "        filter_fir_taps: None\n",
+            "        filter_iir_taps: None\n",
+            "        opx_output_offset: None\n",
+            "        intermediate_frequency: None\n",
+            "      resonator: InOutIQChannel\n",
+            "        operations: QuamDict Empty\n",
+            "        id: 1\n",
+            "        digital_outputs: QuamDict Empty\n",
+            "        opx_output_I: ('con1', 4)\n",
+            "        opx_output_Q: ('con1', 5)\n",
+            "        opx_output_offset_I: None\n",
+            "        opx_output_offset_Q: None\n",
+            "        frequency_converter_up: FrequencyConverter\n",
+            "          local_oscillator: LocalOscillator\n",
+            "            frequency: 6000000000.0\n",
+            "            power: 10\n",
+            "          mixer: Mixer\n",
+            "            local_oscillator_frequency: \"#../local_oscillator/frequency\"\n",
+            "            intermediate_frequency: \"#../../intermediate_frequency\"\n",
+            "            correction_gain: 0\n",
+            "            correction_phase: 0\n",
+            "          gain: None\n",
+            "        intermediate_frequency: 0.0\n",
+            "        opx_input_I: ('con1', 1)\n",
+            "        opx_input_Q: ('con1', 2)\n",
+            "        time_of_flight: 140\n",
+            "        smearing: 0\n",
+            "        opx_input_offset_I: None\n",
+            "        opx_input_offset_Q: None\n",
+            "        input_gain: None\n",
+            "        frequency_converter_down: None\n",
+            "  wiring: QuamDict Empty\n"
+          ]
+        }
+      ],
+      "source": [
+        "num_qubits = 2\n",
+        "for idx in range(num_qubits):\n",
+        "    # Create qubit components\n",
+        "    transmon = Transmon(\n",
+        "        id=idx,\n",
+        "        xy=IQChannel(\n",
+        "            opx_output_I=(\"con1\", 3 * idx + 3),\n",
+        "            opx_output_Q=(\"con1\", 3 * idx + 4),\n",
+        "            frequency_converter_up=FrequencyConverter(\n",
+        "                mixer=Mixer(),\n",
+        "                local_oscillator=LocalOscillator(power=10, frequency=6e9),\n",
+        "            ),\n",
+        "            intermediate_frequency=100e6,\n",
+        "        ),\n",
+        "        z=SingleChannel(opx_output=(\"con1\", 3 * idx + 5)),\n",
+        "    )\n",
+        "    machine.qubits[transmon.name] = transmon\n",
+        "    readout_resonator = InOutIQChannel(\n",
+        "        id=idx,\n",
+        "        opx_output_I=(\"con1\", 3 * idx + 1),\n",
+        "        opx_output_Q=(\"con1\", 3 * idx + 2),\n",
+        "        opx_input_I=(\"con1\", 1),\n",
+        "        opx_input_Q=(\"con1\", 2,),\n",
+        "        frequency_converter_up=FrequencyConverter(\n",
+        "            mixer=Mixer(), local_oscillator=LocalOscillator(power=10, frequency=6e9)\n",
+        "        ),\n",
+        "    )\n",
+        "    transmon.resonator = readout_resonator\n",
+        "\n",
+        "machine.print_summary()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "A summary of QUAM can be shown using `machine.print_summary()`"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Saving and Loading QUAM"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We can then save quam to a json file:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "machine.save(root_folder / \"basic\" / \"state.json\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Finally, we can also load quam from the same json file"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {},
+      "outputs": [
+        {
+          "ename": "NameError",
+          "evalue": "name 'Quam' is not defined",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+            "Cell \u001b[0;32mIn[5], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m loaded_quam \u001b[38;5;241m=\u001b[39m \u001b[43mQuam\u001b[49m\u001b[38;5;241m.\u001b[39mload(root_folder \u001b[38;5;241m/\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbasic\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m/\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstate.json\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+            "\u001b[0;31mNameError\u001b[0m: name 'Quam' is not defined"
+          ]
+        }
+      ],
+      "source": [
+        "loaded_quam = Quam.load(root_folder / \"basic\" / \"state.json\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Importantly, the `state.json` file only describes how QuAM is structured, and how the different QuAM components should be initialized. The components themselves are defined in their respective classes."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Generating QUA Configuration"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We can also generate the qua config from quam. This recursively calls `QuamComponent.apply_to_config()` on all quam components."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "qua_config = machine.generate_config()\n",
+        "json.dump(qua_config, open(root_folder / \"basic\" / \"qua_config.json\", \"w\"), indent=2)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "PosixPath('output/basic/qua_config.json')"
+            ]
+          },
+          "execution_count": 7,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "root_folder / \"basic\" / \"qua_config.json\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## QUAM Using References"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "QuAM allows values to reference another part of QuAM by setting its value to a string starting with a colon: `\"#/path/to/referenced/value\"`.\n",
+        "\n",
+        "As an example why this is useful, we previously hardcoded all output ports. However, grouping everything at a top-level `\"wiring\"`` makes more sense, so we can have all output ports reference to it.\n",
+        "\n",
+        "Below we also add several more references"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "QuAM:\n",
+            "  qubits: QuamDict\n",
+            "    q0: Transmon\n",
+            "      id: 0\n",
+            "      xy: IQChannel\n",
+            "        operations: QuamDict Empty\n",
+            "        id: None\n",
+            "        digital_outputs: QuamDict Empty\n",
+            "        opx_output_I: \"#/wiring/qubits/q0/port_I\"\n",
+            "        opx_output_Q: \"#/wiring/qubits/q0/port_Q\"\n",
+            "        opx_output_offset_I: None\n",
+            "        opx_output_offset_Q: None\n",
+            "        frequency_converter_up: FrequencyConverter\n",
+            "          local_oscillator: LocalOscillator\n",
+            "            frequency: 6000000000.0\n",
+            "            power: 10\n",
+            "          mixer: Mixer\n",
+            "            local_oscillator_frequency: \"#../local_oscillator/frequency\"\n",
+            "            intermediate_frequency: \"#../../intermediate_frequency\"\n",
+            "            correction_gain: 0\n",
+            "            correction_phase: 0\n",
+            "          gain: None\n",
+            "        intermediate_frequency: 100000000.0\n",
+            "      z: SingleChannel\n",
+            "        operations: QuamDict Empty\n",
+            "        id: None\n",
+            "        digital_outputs: QuamDict Empty\n",
+            "        opx_output: \"#/wiring/qubits/q0/port_Z\"\n",
+            "        filter_fir_taps: None\n",
+            "        filter_iir_taps: None\n",
+            "        opx_output_offset: None\n",
+            "        intermediate_frequency: None\n",
+            "      resonator: InOutIQChannel\n",
+            "        operations: QuamDict Empty\n",
+            "        id: 0\n",
+            "        digital_outputs: QuamDict Empty\n",
+            "        opx_output_I: \"#/wiring/feedline/opx_output_I\"\n",
+            "        opx_output_Q: \"#/wiring/feedline/opx_output_Q\"\n",
+            "        opx_output_offset_I: None\n",
+            "        opx_output_offset_Q: None\n",
+            "        frequency_converter_up: FrequencyConverter\n",
+            "          local_oscillator: LocalOscillator\n",
+            "            frequency: 6000000000.0\n",
+            "            power: 10\n",
+            "          mixer: Mixer\n",
+            "            local_oscillator_frequency: \"#../local_oscillator/frequency\"\n",
+            "            intermediate_frequency: \"#../../intermediate_frequency\"\n",
+            "            correction_gain: 0\n",
+            "            correction_phase: 0\n",
+            "          gain: None\n",
+            "        intermediate_frequency: 0.0\n",
+            "        opx_input_I: \"#/wiring/feedline/opx_input_I\"\n",
+            "        opx_input_Q: \"#/wiring/feedline/opx_input_Q\"\n",
+            "        time_of_flight: 140\n",
+            "        smearing: 0\n",
+            "        opx_input_offset_I: None\n",
+            "        opx_input_offset_Q: None\n",
+            "        input_gain: None\n",
+            "        frequency_converter_down: None\n",
+            "    q1: Transmon\n",
+            "      id: 1\n",
+            "      xy: IQChannel\n",
+            "        operations: QuamDict Empty\n",
+            "        id: None\n",
+            "        digital_outputs: QuamDict Empty\n",
+            "        opx_output_I: \"#/wiring/qubits/q1/port_I\"\n",
+            "        opx_output_Q: \"#/wiring/qubits/q1/port_Q\"\n",
+            "        opx_output_offset_I: None\n",
+            "        opx_output_offset_Q: None\n",
+            "        frequency_converter_up: FrequencyConverter\n",
+            "          local_oscillator: LocalOscillator\n",
+            "            frequency: 6000000000.0\n",
+            "            power: 10\n",
+            "          mixer: Mixer\n",
+            "            local_oscillator_frequency: \"#../local_oscillator/frequency\"\n",
+            "            intermediate_frequency: \"#../../intermediate_frequency\"\n",
+            "            correction_gain: 0\n",
+            "            correction_phase: 0\n",
+            "          gain: None\n",
+            "        intermediate_frequency: 100000000.0\n",
+            "      z: SingleChannel\n",
+            "        operations: QuamDict Empty\n",
+            "        id: None\n",
+            "        digital_outputs: QuamDict Empty\n",
+            "        opx_output: \"#/wiring/qubits/q1/port_Z\"\n",
+            "        filter_fir_taps: None\n",
+            "        filter_iir_taps: None\n",
+            "        opx_output_offset: None\n",
+            "        intermediate_frequency: None\n",
+            "      resonator: InOutIQChannel\n",
+            "        operations: QuamDict Empty\n",
+            "        id: 1\n",
+            "        digital_outputs: QuamDict Empty\n",
+            "        opx_output_I: \"#/wiring/feedline/opx_output_I\"\n",
+            "        opx_output_Q: \"#/wiring/feedline/opx_output_Q\"\n",
+            "        opx_output_offset_I: None\n",
+            "        opx_output_offset_Q: None\n",
+            "        frequency_converter_up: FrequencyConverter\n",
+            "          local_oscillator: LocalOscillator\n",
+            "            frequency: 6000000000.0\n",
+            "            power: 10\n",
+            "          mixer: Mixer\n",
+            "            local_oscillator_frequency: \"#../local_oscillator/frequency\"\n",
+            "            intermediate_frequency: \"#../../intermediate_frequency\"\n",
+            "            correction_gain: 0\n",
+            "            correction_phase: 0\n",
+            "          gain: None\n",
+            "        intermediate_frequency: 0.0\n",
+            "        opx_input_I: \"#/wiring/feedline/opx_input_I\"\n",
+            "        opx_input_Q: \"#/wiring/feedline/opx_input_Q\"\n",
+            "        time_of_flight: 140\n",
+            "        smearing: 0\n",
+            "        opx_input_offset_I: None\n",
+            "        opx_input_offset_Q: None\n",
+            "        input_gain: None\n",
+            "        frequency_converter_down: None\n",
+            "  wiring: QuamDict\n",
+            "    qubits: QuamDict\n",
+            "      q0: QuamDict\n",
+            "        port_I: ('con1', 3)\n",
+            "        port_Q: ('con1', 4)\n",
+            "        port_Z: ('con1', 5)\n",
+            "      q1: QuamDict\n",
+            "        port_I: ('con1', 6)\n",
+            "        port_Q: ('con1', 7)\n",
+            "        port_Z: ('con1', 8)\n",
+            "    feedline: QuamDict\n",
+            "      opx_output_I: ('con1', 1)\n",
+            "      opx_output_Q: ('con1', 2)\n",
+            "      opx_input_I: ('con1', 1)\n",
+            "      opx_input_Q: ('con1', 2)\n"
+          ]
+        }
+      ],
+      "source": [
+        "num_qubits = 2\n",
+        "machine = Quam()\n",
+        "machine.wiring = {\n",
+        "    \"qubits\": {\n",
+        "        f\"q{idx}\": {\n",
+        "            \"port_I\": (\"con1\", 3 * idx + 3),\n",
+        "            \"port_Q\": (\"con1\", 3 * idx + 4),\n",
+        "            \"port_Z\": (\"con1\", 3 * idx + 5),\n",
+        "        }\n",
+        "        for idx in range(num_qubits)\n",
+        "    },\n",
+        "    \"feedline\": {\n",
+        "        \"opx_output_I\": (\"con1\", 1),\n",
+        "        \"opx_output_Q\": (\"con1\", 2),\n",
+        "        \"opx_input_I\": (\"con1\", 1),\n",
+        "        \"opx_input_Q\": (\"con1\", 2),\n",
+        "    },\n",
+        "}\n",
+        "\n",
+        "for idx in range(num_qubits):\n",
+        "    # Create qubit components\n",
+        "    transmon = Transmon(\n",
+        "        id=idx,\n",
+        "        xy=IQChannel(\n",
+        "            opx_output_I=f\"#/wiring/qubits/q{idx}/port_I\",\n",
+        "            opx_output_Q=f\"#/wiring/qubits/q{idx}/port_Q\",\n",
+        "            frequency_converter_up=FrequencyConverter(\n",
+        "                mixer=Mixer(),\n",
+        "                local_oscillator=LocalOscillator(power=10, frequency=6e9),\n",
+        "            ),\n",
+        "            intermediate_frequency=100e6,\n",
+        "        ),\n",
+        "        z=SingleChannel(opx_output=f\"#/wiring/qubits/q{idx}/port_Z\"),\n",
+        "    )\n",
+        "    machine.qubits[transmon.name] = transmon\n",
+        "    readout_resonator = InOutIQChannel(\n",
+        "        id=idx,\n",
+        "        opx_output_I=\"#/wiring/feedline/opx_output_I\",\n",
+        "        opx_output_Q=\"#/wiring/feedline/opx_output_Q\",\n",
+        "        opx_input_I=\"#/wiring/feedline/opx_input_I\",\n",
+        "        opx_input_Q=\"#/wiring/feedline/opx_input_Q\",\n",
+        "        frequency_converter_up=FrequencyConverter(\n",
+        "            mixer=Mixer(), local_oscillator=LocalOscillator(power=10, frequency=6e9)\n",
+        "        ),\n",
+        "    )\n",
+        "    transmon.resonator = readout_resonator\n",
+        "\n",
+        "machine.print_summary()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We again save quam and the QUA config. The QUA config is identical to previous, but QUAM has changed significantly"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "machine.save(root_folder / \"referenced\" / \"state.json\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "qua_config = machine.generate_config()\n",
+        "json.dump(qua_config, open(root_folder / \"referenced\" / \"qua_config.json\", \"w\"), indent=2)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Separating QUAM into Multiple Files"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Finally, we can also separate parts of QuAM to be placed into a separate file.\n",
+        "This can be especially useful when combined with referencing because we can now have a separate file dedicated to the wiring of the experiment.\n",
+        "\n",
+        "Here we point quam to a folder instead of a json file, and we specify that `\"wiring\"` should go to a separate `wiring.json` file in that folder:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "machine.save(root_folder / \"referenced_multifile\" / \"quam\", content_mapping={\"wiring.json\": [\"wiring\"]})"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "It can subseuently be loaded as usual"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "machine = Quam.load(root_folder / \"referenced_multifile\" / \"quam\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Separating QUAM into multiple files allows the user to revert back to a previous QUAM but keep some parts the same.\n",
+        "For example, the user may want to revert all experimental settings, but the wiring of the setup should of course not change."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": []
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.11"
+    },
+    "orig_nbformat": 4
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
 }

--- a/docs/examples/output/basic/qua_config.json
+++ b/docs/examples/output/basic/qua_config.json
@@ -81,7 +81,7 @@
         "lo_frequency": 6000000000.0
       },
       "smearing": 0,
-      "time_of_flight": 24,
+      "time_of_flight": 140,
       "outputs": {
         "out1": [
           "con1",
@@ -134,7 +134,7 @@
         "lo_frequency": 6000000000.0
       },
       "smearing": 0,
-      "time_of_flight": 24,
+      "time_of_flight": 140,
       "outputs": {
         "out1": [
           "con1",

--- a/docs/examples/output/referenced/qua_config.json
+++ b/docs/examples/output/referenced/qua_config.json
@@ -81,7 +81,7 @@
         "lo_frequency": 6000000000.0
       },
       "smearing": 0,
-      "time_of_flight": 24,
+      "time_of_flight": 140,
       "outputs": {
         "out1": [
           "con1",
@@ -134,7 +134,7 @@
         "lo_frequency": 6000000000.0
       },
       "smearing": 0,
-      "time_of_flight": 24,
+      "time_of_flight": 140,
       "outputs": {
         "out1": [
           "con1",

--- a/docs/features/gate-level-operations.md
+++ b/docs/features/gate-level-operations.md
@@ -126,7 +126,7 @@ q1: Transmon
     thread: None
     core: None
     opx_input: "#/ports/mw_inputs/con1/1/2"
-    time_of_flight: 24
+    time_of_flight: 140
     smearing: 0
     LO_frequency: "#./upconverter_frequency"
     RF_frequency: "#./inferred_RF_frequency"
@@ -157,7 +157,7 @@ q1 @ q2
 /// details | `q1 @ q2` output
 
 ```
-QubitPair(id='q1@q2', macros={}, qubit_control=Transmon(id='q1', macros={}, xy=MWChannel(operations={}, id=None, digital_outputs={}, sticky=None, intermediate_frequency=100000000.0, thread=None, core=None, LO_frequency=5000000000.0, RF_frequency=5100000000.0, opx_output=MWFEMAnalogOutputPort(controller_id='con1', fem_id=1, port_id=1, band=1, upconverter_frequency=5000000000.0, upconverters=None, delay=0, shareable=False, sampling_rate=1000000000.0, full_scale_power_dbm=-11), upconverter=1), resonator=InOutMWChannel(operations={}, id=None, digital_outputs={}, sticky=None, intermediate_frequency=100000000.0, thread=None, core=None, opx_input=MWFEMAnalogInputPort(controller_id='con1', fem_id=1, port_id=2, band=1, downconverter_frequency=5000000000.0, gain_db=None, sampling_rate=1000000000.0, shareable=False), time_of_flight=24, smearing=0, LO_frequency=5000000000.0, RF_frequency=5100000000.0, opx_output=MWFEMAnalogOutputPort(controller_id='con1', fem_id=1, port_id=2, band=1, upconverter_frequency=5000000000.0, upconverters=None, delay=0, shareable=False, sampling_rate=1000000000.0, full_scale_power_dbm=-11), upconverter=1)), qubit_target=Transmon(id='q2', macros={}, xy=MWChannel(operations={}, id=None, digital_outputs={}, sticky=None, intermediate_frequency=100000000.0, thread=None, core=None, LO_frequency=5000000000.0, RF_frequency=5100000000.0, opx_output=MWFEMAnalogOutputPort(controller_id='con1', fem_id=1, port_id=2, band=1, upconverter_frequency=5000000000.0, upconverters=None, delay=0, shareable=False, sampling_rate=1000000000.0, full_scale_power_dbm=-11), upconverter=1), resonator=None))
+QubitPair(id='q1@q2', macros={}, qubit_control=Transmon(id='q1', macros={}, xy=MWChannel(operations={}, id=None, digital_outputs={}, sticky=None, intermediate_frequency=100000000.0, thread=None, core=None, LO_frequency=5000000000.0, RF_frequency=5100000000.0, opx_output=MWFEMAnalogOutputPort(controller_id='con1', fem_id=1, port_id=1, band=1, upconverter_frequency=5000000000.0, upconverters=None, delay=0, shareable=False, sampling_rate=1000000000.0, full_scale_power_dbm=-11), upconverter=1), resonator=InOutMWChannel(operations={}, id=None, digital_outputs={}, sticky=None, intermediate_frequency=100000000.0, thread=None, core=None, opx_input=MWFEMAnalogInputPort(controller_id='con1', fem_id=1, port_id=2, band=1, downconverter_frequency=5000000000.0, gain_db=None, sampling_rate=1000000000.0, shareable=False), time_of_flight=140, smearing=0, LO_frequency=5000000000.0, RF_frequency=5100000000.0, opx_output=MWFEMAnalogOutputPort(controller_id='con1', fem_id=1, port_id=2, band=1, upconverter_frequency=5000000000.0, upconverters=None, delay=0, shareable=False, sampling_rate=1000000000.0, full_scale_power_dbm=-11), upconverter=1)), qubit_target=Transmon(id='q2', macros={}, xy=MWChannel(operations={}, id=None, digital_outputs={}, sticky=None, intermediate_frequency=100000000.0, thread=None, core=None, LO_frequency=5000000000.0, RF_frequency=5100000000.0, opx_output=MWFEMAnalogOutputPort(controller_id='con1', fem_id=1, port_id=2, band=1, upconverter_frequency=5000000000.0, upconverters=None, delay=0, shareable=False, sampling_rate=1000000000.0, full_scale_power_dbm=-11), upconverter=1), resonator=None))
 ```
 
 ///

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -57,7 +57,7 @@ from qm.qua import (
     frame_rotation,
     frame_rotation_2pi,
     time_tagging,
-    reset_if_phase
+    reset_if_phase,
 )
 
 __all__ = [
@@ -779,7 +779,7 @@ class InSingleChannel(Channel):
     opx_input: LF_input_port_types
     opx_input_offset: float = None
 
-    time_of_flight: int = 24
+    time_of_flight: int = 140
     smearing: int = 0
 
     time_tagging: Optional[TimeTaggingAddon] = None
@@ -1282,14 +1282,13 @@ class IQChannel(_OutComplexChannel):
                 f"reference: {self.frequency_converter_up}"
             )
         else:
-
             element_config["mixInputs"] = {}  # To be filled in next section
             if self.mixer is not None:
                 element_config["mixInputs"]["mixer"] = self.mixer.name
             if self.local_oscillator is not None:
-                element_config["mixInputs"][
-                    "lo_frequency"
-                ] = self.local_oscillator.frequency
+                element_config["mixInputs"]["lo_frequency"] = (
+                    self.local_oscillator.frequency
+                )
 
         opx_outputs = [self.opx_output_I, self.opx_output_Q]
         offsets = [self.opx_output_offset_I, self.opx_output_offset_Q]
@@ -1587,7 +1586,7 @@ class InIQChannel(_InComplexChannel):
     opx_input_I: LF_input_port_types
     opx_input_Q: LF_input_port_types
 
-    time_of_flight: int = 24
+    time_of_flight: int = 140
     smearing: int = 0
 
     opx_input_offset_I: float = None
@@ -1869,7 +1868,7 @@ class InMWChannel(_InComplexChannel):
 
     opx_input: MWFEMAnalogInputPort
 
-    time_of_flight: int = 24
+    time_of_flight: int = 140
     smearing: int = 0
 
     def apply_to_config(self, config: Dict) -> None:

--- a/tests/components/channels/test_in_IQ_out_single_channel.py
+++ b/tests/components/channels/test_in_IQ_out_single_channel.py
@@ -58,7 +58,7 @@ def test_generate_config(qua_config):
             "outputs": {"out1": ("con1", 1), "out2": ("con1", 2)},
             "singleInput": {"port": ("con1", 1)},
             "smearing": 0,
-            "time_of_flight": 24,
+            "time_of_flight": 140,
         }
     }
 
@@ -93,6 +93,6 @@ def test_generate_config_ports(qua_config):
             "outputs": {"out1": ("con1", 1), "out2": ("con1", 2)},
             "singleInput": {"port": ("con1", 1)},
             "smearing": 0,
-            "time_of_flight": 24,
+            "time_of_flight": 140,
         }
     }

--- a/tests/components/channels/test_in_out_IQ_channel.py
+++ b/tests/components/channels/test_in_out_IQ_channel.py
@@ -91,7 +91,7 @@ def test_empty_in_out_IQ_channel():
                 "operations": {},
                 "outputs": {"out1": ("con1", 3), "out2": ("con1", 4)},
                 "smearing": 0,
-                "time_of_flight": 24,
+                "time_of_flight": 140,
             }
         },
         "pulses": {},
@@ -188,7 +188,7 @@ def test_readout_resonator_with_readout():
                 },
                 "outputs": {"out1": ("con1", 3), "out2": ("con1", 4)},
                 "smearing": 0,
-                "time_of_flight": 24,
+                "time_of_flight": 140,
                 "operations": {"readout": "IQ1.readout.pulse"},
             }
         },
@@ -369,7 +369,7 @@ def test_empty_in_out_IQ_channel_ports():
                 "operations": {},
                 "outputs": {"out1": ("con1", 3), "out2": ("con1", 4)},
                 "smearing": 0,
-                "time_of_flight": 24,
+                "time_of_flight": 140,
             }
         },
         "pulses": {},

--- a/tests/components/channels/test_in_out_single_channel.py
+++ b/tests/components/channels/test_in_out_single_channel.py
@@ -42,7 +42,7 @@ def test_in_out_single_channel():
                 "outputs": {"out1": ("con1", 2)},
                 "singleInput": {"port": ("con1", 1)},
                 "smearing": 0,
-                "time_of_flight": 24,
+                "time_of_flight": 140,
             }
         },
     }
@@ -76,7 +76,7 @@ def test_in_out_single_channel_ports():
                 "outputs": {"out1": ("con1", 2)},
                 "singleInput": {"port": ("con1", 1)},
                 "smearing": 0,
-                "time_of_flight": 24,
+                "time_of_flight": 140,
             }
         },
     }

--- a/tests/components/channels/test_in_single_channel.py
+++ b/tests/components/channels/test_in_single_channel.py
@@ -39,7 +39,7 @@ def test_generate_config(qua_config):
             "operations": {},
             "outputs": {"out1": ("con1", 1)},
             "smearing": 0,
-            "time_of_flight": 24,
+            "time_of_flight": 140,
         }
     }
 
@@ -65,6 +65,6 @@ def test_generate_config_ports(qua_config):
             "operations": {},
             "outputs": {"out1": ("con1", 1)},
             "smearing": 0,
-            "time_of_flight": 24,
+            "time_of_flight": 140,
         }
     }

--- a/tests/components/channels/test_in_single_out_IQ_channel.py
+++ b/tests/components/channels/test_in_single_out_IQ_channel.py
@@ -64,7 +64,7 @@ def test_generate_config(qua_config):
             "operations": {},
             "outputs": {"out1": ("con1", 1)},
             "smearing": 0,
-            "time_of_flight": 24,
+            "time_of_flight": 140,
         }
     }
 
@@ -104,6 +104,6 @@ def test_generate_config(qua_config):
             "operations": {},
             "outputs": {"out1": ("con1", 1)},
             "smearing": 0,
-            "time_of_flight": 24,
+            "time_of_flight": 140,
         }
     }

--- a/tests/components/test_octave.py
+++ b/tests/components/test_octave.py
@@ -308,7 +308,7 @@ def test_channel_add_RF_inputs(octave, qua_config):
             "RF_outputs": {"port": ("octave1", 4)},
             "operations": {},
             "smearing": 0,
-            "time_of_flight": 24,
+            "time_of_flight": 140,
         }
     }
 


### PR DESCRIPTION
Changed default `time_of_flight` from 24 ns to 140 ns to fix error on newer qm-qua versions
- 140 ns seems like a reasonable default for most channels