### PR TITLE
Fix type annotation in QuamRoot.load() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fixed `QuamBase.get_attr_name()` failing when an attribute was a reference.
 - Fixed arbitrary waveforms on IQ/MW channels not converting Q component to list consistently
+- Fixed type annotation issue in `QuamRoot.load()` method causing linting errors for subclasses like `BasicQuam`
 
 ## [0.4.0]
 

--- a/quam/core/quam_classes.py
+++ b/quam/core/quam_classes.py
@@ -766,7 +766,7 @@ class QuamRoot(QuamBase):
 
     @classmethod
     def load(
-        cls: QuamRootType,
+        cls: type[QuamRootType],
         filepath_or_dict: Optional[Union[str, Path, dict]] = None,
         validate_type: bool = True,
         fix_attrs: bool = True,


### PR DESCRIPTION
- Changed cls parameter type from QuamRootType to type[QuamRootType]
- This resolves linting errors when calling load() on subclasses like BasicQuam
- The fix ensures proper type checking for class methods in the inheritance chain