### PR TITLE
Update min qm-qua version ≥ 1.22 and add prerelease allow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ keywords = [
 
 dependencies = [
     "numpy >= 1.21.2",
-    "qm-qua >=1.1.0",
+    "qm-qua >=1.2.2",
     "qualang-tools >= 0.15.0",
     "typeguard >= 4.1.0",
     "qualibrate-config >= 0.1.4",
@@ -73,6 +73,8 @@ packages = ["quam"]
 version_scheme = "only-version"
 local_scheme = "no-local-version"
 
+[tool.uv]
+prerelease = "allow"
 
 # Previous quam settings
 


### PR DESCRIPTION
## Summary
- Updated qm-qua minimum version requirement from 1.1.0 to 1.2.2
- Added prerelease = "allow" configuration under [tool.uv] section

## Changes
- **pyproject.toml**: Updated `qm-qua` dependency version and added UV prerelease configuration

## Test plan
- [x] Changes applied to pyproject.toml
- [x] Verify dependency resolution works with new qm-qua version
- [x] Test that prerelease packages can be installed when needed