### PR TITLE
fix: mock get_quam_config in tests to prevent loading system config

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 import pytest
+from unittest.mock import patch
 
 from quam.core import *
 
@@ -32,3 +33,11 @@ def qua_config():
     from quam.core.qua_config_template import qua_config_template
 
     return deepcopy(qua_config_template)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def mock_quam_config():
+    """Mock get_quam_config to prevent loading system config during tests."""
+    with patch('quam.core.quam_classes.get_quam_config') as mock:
+        mock.side_effect = FileNotFoundError("No config file in test environment")
+        yield mock


### PR DESCRIPTION
## Problem
Recent commits caused 5 tests to fail when the system had a mismatched QUAM config version:
- `tests/quam_base/referencing/test_referencing_dict.py::test_referencing_from_dict`
- `tests/quam_base/referencing/test_referencing_list.py::test_referencing_from_list`
- `tests/quam_base/test_set_at_reference.py::test_set_at_reference_invalid_reference`
- `tests/quam_base/test_set_at_reference.py::test_set_at_absolute_reference_invalid`
- `tests/quam_base/test_set_at_reference.py::test_set_double_reference_to_nonexistent_item`

## Root Cause
Tests were loading the system config file (`~/.qualibrate/config.toml`) during execution. When the config had version 3 but the code expected version 2, it attempted to migrate using `v2_v3.py` migration file which doesn't exist, causing a `ModuleNotFoundError` that propagated through the test.

This violated test isolation principles - tests should not depend on system configuration state.

## Solution
Added a global autouse fixture in `tests/conftest.py` that mocks `get_quam_config()` to always raise `FileNotFoundError` during test execution. This ensures:
- Tests use default config behavior (no config file)
- Test isolation from system state
- Consistent test results across different environments

## Changes
- **tests/conftest.py**: Added `mock_quam_config` fixture with `autouse=True`
