### PR TITLE
Change allow_non_reference default to True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Changed
 
+- **Breaking Change**: `set_at_reference()` method now defaults to `allow_non_reference=True` instead of `False`. This aligns with real-world usage patterns and improves developer experience. Users requiring error-by-default can explicitly pass `allow_non_reference=False`.
 - **Breaking Change**: Default serialization behavior changed from excluding defaults to including them for more explicit state representation
 - Config version bumped from v2 to v3
 - Restructured config to use nested `serialization` subcategory under `quam` config section

--- a/quam/components/hardware.py
+++ b/quam/components/hardware.py
@@ -150,9 +150,7 @@ class FrequencyConverter(BaseFrequencyConverter):
 
         # Use set_at_reference to ensure the frequency is updated, even if the local
         # oscillator frequency is a reference
-        self.local_oscillator.set_at_reference(
-            "frequency", value, allow_non_reference=True
-        )
+        self.local_oscillator.set_at_reference("frequency", value)
 
     def configure(self):
         if self.local_oscillator is not None:

--- a/quam/core/quam_classes.py
+++ b/quam/core/quam_classes.py
@@ -738,7 +738,7 @@ class QuamBase(ReferenceClass):
         return self._follow_reference_chain(parent_obj, parent_attr, max_depth - 1)
 
     def set_at_reference(
-        self, attr: str, value: Any, allow_non_reference: bool = False
+        self, attr: str, value: Any, allow_non_reference: bool = True
     ):
         """Follow the reference of an attribute and set the value at the reference.
 
@@ -750,7 +750,8 @@ class QuamBase(ReferenceClass):
             attr: The attribute to set the value at the reference of.
             value: The value to set.
             allow_non_reference: Whether to allow the attribute to be a non-reference.
-                If False, the attribute must be a reference or an error is raised.
+                If True (default), non-reference attributes are allowed. If False,
+                the attribute must be a reference or an error is raised.
 
         Raises:
             ValueError: If the attribute is not a reference and `allow_non_reference` is

--- a/tests/quam_base/test_reference_chains.py
+++ b/tests/quam_base/test_reference_chains.py
@@ -408,14 +408,19 @@ def test_set_at_absolute_reference():
 
 
 def test_set_at_reference_non_reference_raises():
-    """set_at_reference on non-reference should raise ValueError."""
+    """set_at_reference on non-reference now works with new default."""
     root = QuamRootForTesting(
         target=SimpleTarget(value=0),
     )
     root.normal_value = 42
 
+    # With new default (allow_non_reference=True), this should succeed
+    root.set_at_reference("normal_value", 123)
+    assert root.normal_value == 123
+
+    # Explicitly passing allow_non_reference=False should raise ValueError
     with pytest.raises(ValueError, match="is not a reference"):
-        root.set_at_reference("normal_value", 123)
+        root.set_at_reference("normal_value", 456, allow_non_reference=False)
 
 
 # Edge cases and error handling

--- a/tests/quam_base/test_set_at_reference.py
+++ b/tests/quam_base/test_set_at_reference.py
@@ -35,11 +35,16 @@ def test_set_at_reference():
 
 
 def test_set_at_reference_non_reference():
-    """Test that setting a non-reference attribute raises ValueError"""
+    """Test that setting a non-reference attribute succeeds with new default"""
     parent = ParentQuam(child=ChildQuam())
 
+    # With allow_non_reference=True (new default), this should succeed
+    parent.set_at_reference("normal_value", 123)
+    assert parent.normal_value == 123
+
+    # Explicitly passing allow_non_reference=False should raise ValueError
     with pytest.raises(ValueError, match="is not a reference"):
-        parent.set_at_reference("normal_value", 123)
+        parent.set_at_reference("normal_value", 456, allow_non_reference=False)
 
 
 def test_set_at_reference_invalid_reference():
@@ -167,15 +172,15 @@ def test_set_triple_reference():
 
 
 def test_set_at_reference_allow_non_reference():
-    """Test setting a value through a reference with allow_non_reference=True"""
+    """Test setting a value through a reference with allow_non_reference parameter"""
     parent = ParentQuam(child=ChildQuam(value=42), ref_value="#./child/value")
-    parent.set_at_reference("ref_value", 789, allow_non_reference=True)
+    # With new default (allow_non_reference=True), following reference should work
+    parent.set_at_reference("ref_value", 789)
     assert parent.ref_value == 789
 
-    with pytest.raises(ValueError):
-        parent.child.set_at_reference("value", 43)
-
-    assert parent.child.value == 789
+    # Non-reference attribute should also work now with default True
+    parent.child.set_at_reference("value", 43)
+    assert parent.child.value == 43
 
 
 @quam_dataclass


### PR DESCRIPTION
## Summary

Breaking change: `set_at_reference()` now defaults to `allow_non_reference=True` instead of `False`. Aligns with real-world usage patterns in the codebase.

## Changes

- Updated default parameter in `set_at_reference()` 
- Updated 4 tests to reflect new behavior
- Removed redundant parameter from `FrequencyConverter.LO_frequency` setter

Addresses #170 