### PR TITLE
Add ramp and ramp_to_zero support to Channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- Added `Channel.ramp(slope, duration)` method for playing linear voltage ramps
+- Added `Channel.ramp_to_zero(duration)` method for ramping channel output to zero
 - Added `FEMPortsContainer` and `OPXPlusPortsContainer` for centralized port management
 - Added `BasicFEMQuam` and `BasicOPXPlusQuam` classes with integrated port containers
 - Added helper function `_create_port_property_deprecation_message()` to provide detailed migration guidance in deprecation warnings

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -58,6 +58,8 @@ from qm.qua import (
     frame_rotation_2pi,
     time_tagging,
     reset_if_phase,
+    ramp as qua_ramp,
+    ramp_to_zero as qua_ramp_to_zero,
 )
 
 __all__ = [
@@ -453,7 +455,8 @@ class Channel(QuamComponent, ABC):
 
         Args:
             pulse_name (str): The name of the pulse to play. Should be registered in
-                `self.operations`.
+                `self.operations`. Can also be a ``ramp(slope)`` object from
+                ``qm.qua``, in which case validation is skipped automatically.
             amplitude_scale (Optional[Union[ScalarFloat, Sequence[ScalarFloat]]]):
                 Amplitude scale of the pulse. Can be either a (qua) float, or a list of
                 (qua) floats. If None, the pulse is played without amplitude scaling.
@@ -461,7 +464,7 @@ class Channel(QuamComponent, ABC):
                 clock cycle (4ns). If not provided, the default pulse duration will be
                 used. It is possible to dynamically change the duration of both constant
                 and arbitrary pulses. Arbitrary pulses can only be stretched, not
-                compressed
+                compressed. Required when ``pulse_name`` is a ``ramp(slope)`` object.
             chirp (Union[(list[int], str), (int, str)]): Allows to perform
                 piecewise linear sweep of the element's intermediate
                 frequency in time. Input should be a tuple, with the 1st
@@ -483,13 +486,30 @@ class Channel(QuamComponent, ABC):
                 handle can be retrieved with
                 `qm._results.JobResults.get` with the same ``label``.
             validate (bool): If True (default), validate that the pulse is registered
-                in Channel.operations
+                in Channel.operations. Automatically set to False when
+                ``pulse_name`` is a ``ramp(slope)`` object.
 
         Note:
             The `element` argument from `qm.qua.play()`is not needed, as it is
             automatically set to `self.name`.
 
         """
+        from qm.grpc.qua import QuaProgramRampPulse
+
+        if isinstance(pulse_name, QuaProgramRampPulse):
+            play(
+                pulse=pulse_name,
+                element=self.name,
+                duration=duration,
+                condition=condition,
+                chirp=chirp,
+                truncate=truncate,
+                timestamp_stream=timestamp_stream,
+                continue_chirp=continue_chirp,
+                target=target,
+            )
+            return
+
         if validate and pulse_name not in self.operations:
             raise KeyError(
                 f"Operation '{pulse_name}' not found in channel '{self.name}'"
@@ -513,6 +533,42 @@ class Channel(QuamComponent, ABC):
             continue_chirp=continue_chirp,
             target=target,
         )
+
+    def ramp(self, slope: ScalarFloat, duration: ScalarInt):
+        """Play a voltage ramp on this channel.
+
+        Generates a linear voltage ramp using QUA's ``ramp(slope)`` command.
+
+        Args:
+            slope (Scalar[float]): The ramp slope in V/ns.
+            duration (Scalar[int]): Duration of the ramp in units of the
+                clock cycle (4ns). Required.
+
+        Example:
+            ```python
+            with program() as prog:
+                channel.ramp(slope=0.0001, duration=1000)
+            ```
+
+        Note:
+            This is equivalent to ``play(ramp(slope), element, duration=duration)``
+            in QUA. The channel element is set automatically.
+        """
+        play(qua_ramp(slope), self.name, duration=duration)
+
+    def ramp_to_zero(self, duration: Optional[int] = None):
+        """Ramp the channel output gradually to zero from its last DC value.
+
+        Args:
+            duration (int, optional): Duration of the ramp in multiples of 4 ns.
+                Range: [4, 2^24]. If None, the duration is taken from the
+                element's sticky config (``StickyChannelAddon.duration``).
+
+        Note:
+            This does not protect against voltage jumps if the current output
+            value is outside the [-0.5, 0.5 - 2^-16] range.
+        """
+        qua_ramp_to_zero(self.name, duration=duration)
 
     def wait(self, duration: ScalarInt, *other_elements: Union[str, "Channel"]):
         """Wait for the given duration on all provided elements without outputting anything.

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -42,25 +42,7 @@ from quam.utils.qua_types import (
     QuaVariableFloat,
 )
 
-from qm.qua import (
-    align,
-    amp,
-    play,
-    wait,
-    measure,
-    declare,
-    set_dc_offset,
-    fixed,
-    demod,
-    dual_demod,
-    update_frequency,
-    frame_rotation,
-    frame_rotation_2pi,
-    time_tagging,
-    reset_if_phase,
-    ramp as qua_ramp,
-    ramp_to_zero as qua_ramp_to_zero,
-)
+from qm import qua
 
 __all__ = [
     "Channel",
@@ -118,7 +100,11 @@ def _create_port_property_deprecation_message(
     """
     # Infer port property name if not provided
     if port_property_name is None:
-        if property_name.endswith("_offset") or property_name.endswith("_offset_I") or property_name.endswith("_offset_Q"):
+        if (
+            property_name.endswith("_offset")
+            or property_name.endswith("_offset_I")
+            or property_name.endswith("_offset_Q")
+        ):
             port_property_name = "offset"
         elif property_name == "filter_fir_taps":
             port_property_name = "feedforward_filter"
@@ -497,7 +483,7 @@ class Channel(QuamComponent, ABC):
         from qm.grpc.qua import QuaProgramRampPulse
 
         if isinstance(pulse_name, QuaProgramRampPulse):
-            play(
+            qua.play(
                 pulse=pulse_name,
                 element=self.name,
                 duration=duration,
@@ -522,7 +508,7 @@ class Channel(QuamComponent, ABC):
         # At the moment, self.name is not defined for Channel because it could
         # be a property or dataclass field in a subclass.
         # # TODO Find elegant solution for Channel.name.
-        play(
+        qua.play(
             pulse=pulse_name_with_amp_scale,
             element=self.name,
             duration=duration,
@@ -554,7 +540,7 @@ class Channel(QuamComponent, ABC):
             This is equivalent to ``play(ramp(slope), element, duration=duration)``
             in QUA. The channel element is set automatically.
         """
-        play(qua_ramp(slope), self.name, duration=duration)
+        qua.play(qua.ramp(slope), self.name, duration=duration)
 
     def ramp_to_zero(self, duration: Optional[int] = None):
         """Ramp the channel output gradually to zero from its last DC value.
@@ -568,7 +554,7 @@ class Channel(QuamComponent, ABC):
             This does not protect against voltage jumps if the current output
             value is outside the [-0.5, 0.5 - 2^-16] range.
         """
-        qua_ramp_to_zero(self.name, duration=duration)
+        qua.ramp_to_zero(self.name, duration=duration)
 
     def wait(self, duration: ScalarInt, *other_elements: Union[str, "Channel"]):
         """Wait for the given duration on all provided elements without outputting anything.
@@ -598,17 +584,17 @@ class Channel(QuamComponent, ABC):
             element if isinstance(element, str) else str(element)
             for element in other_elements
         ]
-        wait(duration, self.name, *other_elements_str)
+        qua.wait(duration, self.name, *other_elements_str)
 
     def align(self, *other_elements):
         if not other_elements:
-            align()
+            qua.align()
         else:
             other_elements_str = [
                 element if isinstance(element, str) else str(element)
                 for element in other_elements
             ]
-            align(self.name, *other_elements_str)
+            qua.align(self.name, *other_elements_str)
 
     def update_frequency(
         self,
@@ -636,17 +622,17 @@ class Channel(QuamComponent, ABC):
         Example:
             ```python
             with program() as prog:
-                update_frequency("q1", 4e6) # will set the frequency to 4 MHz
+                qua.update_frequency("q1", 4e6) # will set the frequency to 4 MHz
 
                 ### Example for sub-Hz resolution
                 # will set the frequency to 100 Hz (due to casting to int)
-                update_frequency("q1", 100.7)
+                qua.update_frequency("q1", 100.7)
 
                 # will set the frequency to 100.7 Hz
-                update_frequency("q1", 100700, units='mHz')
+                qua.update_frequency("q1", 100700, units='mHz')
             ```
         """
-        update_frequency(self.name, new_frequency, units, keep_phase)
+        qua.update_frequency(self.name, new_frequency, units, keep_phase)
 
     def reset_if_phase(self):
         r"""
@@ -661,7 +647,7 @@ class Channel(QuamComponent, ABC):
         - Reset phase will only reset the phase of the intermediate frequency
           (:math:`\\omega_{IF}`) currently in use.
         """
-        reset_if_phase(self.name)
+        qua.reset_if_phase(self.name)
 
     def frame_rotation(self, angle: ScalarFloat):
         r"""Shift the phase of the channel element's oscillator by the given angle.
@@ -688,7 +674,7 @@ class Channel(QuamComponent, ABC):
                 all of their oscillators' phases will be shifted
 
         """
-        frame_rotation(angle, self.name)
+        qua.frame_rotation(angle, self.name)
 
     def frame_rotation_2pi(self, angle: ScalarFloat):
         r"""Shift the phase of the oscillator associated with an element by the given
@@ -710,7 +696,7 @@ class Channel(QuamComponent, ABC):
             angle (Scalar[float]): The angle to add to the current
                 phase (in $2\pi$ radians)
         """
-        frame_rotation_2pi(angle, self.name)
+        qua.frame_rotation_2pi(angle, self.name)
 
     def _config_add_digital_outputs(self, config: Dict[str, dict]) -> None:
         """Adds the digital outputs to the QUA config.
@@ -832,7 +818,7 @@ class SingleChannel(Channel):
             offset (Scalar[float]): The DC offset to set the input to.
                 This is limited by the OPX output voltage range.
         """
-        set_dc_offset(element=self.name, element_input="single", offset=offset)
+        qua.set_dc_offset(element=self.name, element_input="single", offset=offset)
 
     def apply_to_config(self, config: dict):
         """Adds this SingleChannel to the QUA configuration.
@@ -1016,18 +1002,18 @@ class InSingleChannel(Channel):
                     f"which is not a tuple of two QUA variables. Received {qua_vars=}"
                 )
         else:
-            qua_vars = [declare(fixed) for _ in range(2)]
+            qua_vars = [qua.declare(qua.fixed) for _ in range(2)]
 
         pulse_name_with_amp_scale = add_amplitude_scale_to_pulse_name(
             pulse_name, amplitude_scale
         )
 
         integration_weight_labels = list(pulse.integration_weights_mapping)
-        measure(
+        qua.measure(
             pulse_name_with_amp_scale,
             self.name,
-            demod.full(integration_weight_labels[0], qua_vars[0], "out1"),
-            demod.full(integration_weight_labels[1], qua_vars[1], "out1"),
+            qua.demod.full(integration_weight_labels[0], qua_vars[0], "out1"),
+            qua.demod.full(integration_weight_labels[1], qua_vars[1], "out1"),
             adc_stream=stream,
         )
         return tuple(qua_vars)
@@ -1094,20 +1080,20 @@ class InSingleChannel(Channel):
                     f"which is not a tuple of two QUA variables. Received {qua_vars=}"
                 )
         else:
-            qua_vars = [declare(fixed, size=num_segments) for _ in range(2)]
+            qua_vars = [qua.declare(qua.fixed, size=num_segments) for _ in range(2)]
 
         pulse_name_with_amp_scale = add_amplitude_scale_to_pulse_name(
             pulse_name, amplitude_scale
         )
 
         integration_weight_labels = list(pulse.integration_weights_mapping)
-        measure(
+        qua.measure(
             pulse_name_with_amp_scale,
             self.name,
-            demod.accumulated(
+            qua.demod.accumulated(
                 integration_weight_labels[0], qua_vars[0], segment_length, "out1"
             ),
-            demod.accumulated(
+            qua.demod.accumulated(
                 integration_weight_labels[1], qua_vars[1], segment_length, "out1"
             ),
             adc_stream=stream,
@@ -1176,20 +1162,20 @@ class InSingleChannel(Channel):
                     f"which is not a tuple of two QUA variables. Received {qua_vars=}"
                 )
         else:
-            qua_vars = [declare(fixed, size=num_segments) for _ in range(2)]
+            qua_vars = [qua.declare(qua.fixed, size=num_segments) for _ in range(2)]
 
         pulse_name_with_amp_scale = add_amplitude_scale_to_pulse_name(
             pulse_name, amplitude_scale
         )
 
         integration_weight_labels = list(pulse.integration_weights_mapping)
-        measure(
+        qua.measure(
             pulse_name_with_amp_scale,
             self.name,
-            demod.sliced(
+            qua.demod.sliced(
                 integration_weight_labels[0], qua_vars[0], segment_length, "out1"
             ),
-            demod.sliced(
+            qua.demod.sliced(
                 integration_weight_labels[1], qua_vars[1], segment_length, "out1"
             ),
             adc_stream=stream,
@@ -1233,21 +1219,21 @@ class InSingleChannel(Channel):
             ```
         """
         if mode == "analog":
-            time_tagging_func = time_tagging.analog
+            time_tagging_func = qua.time_tagging.analog
         elif mode == "high_res":
-            time_tagging_func = time_tagging.high_res
+            time_tagging_func = qua.time_tagging.high_res
         elif mode == "digital":
-            time_tagging_func = time_tagging.digital
+            time_tagging_func = qua.time_tagging.digital
         else:
             raise ValueError(f"Invalid time tagging mode: {mode}")
 
         if qua_vars is None:
-            times = declare(int, size=size)
-            counts = declare(int)
+            times = qua.declare(int, size=size)
+            counts = qua.declare(int)
         else:
             times, counts = qua_vars
 
-        measure(
+        qua.measure(
             pulse_name,
             self.name,
             time_tagging_func(target=times, max_time=max_time, targetLen=counts),
@@ -1407,7 +1393,7 @@ class IQChannel(_OutComplexChannel):
             raise ValueError(
                 f"element_input should be either 'I' or 'Q', got {element_input}"
             )
-        set_dc_offset(element=self.name, element_input=element_input, offset=offset)
+        qua.set_dc_offset(element=self.name, element_input=element_input, offset=offset)
 
     def apply_to_config(self, config: dict):
         """Adds this IQChannel to the QUA configuration.
@@ -1471,9 +1457,9 @@ class IQChannel(_OutComplexChannel):
             if self.mixer is not None:
                 element_config["mixInputs"]["mixer"] = self.mixer.name
             if self.local_oscillator is not None:
-                element_config["mixInputs"]["lo_frequency"] = (
-                    self.local_oscillator.frequency
-                )
+                element_config["mixInputs"][
+                    "lo_frequency"
+                ] = self.local_oscillator.frequency
 
         opx_outputs = [self.opx_output_I, self.opx_output_Q]
         offsets = [self.opx_output_offset_I, self.opx_output_offset_Q]
@@ -1539,24 +1525,24 @@ class _InComplexChannel(Channel, ABC):
                     f"tuple of two QUA variables. Received {qua_vars=}"
                 )
         else:
-            qua_vars = [declare(fixed) for _ in range(2)]
+            qua_vars = [qua.declare(qua.fixed) for _ in range(2)]
 
         pulse_name_with_amp_scale = add_amplitude_scale_to_pulse_name(
             pulse_name, amplitude_scale
         )
 
         integration_weight_labels = list(pulse.integration_weights_mapping)
-        measure(
+        qua.measure(
             pulse_name_with_amp_scale,
             self.name,
-            dual_demod.full(
+            qua.dual_demod.full(
                 iw1=integration_weight_labels[0],
                 element_output1="out1",
                 iw2=integration_weight_labels[1],
                 element_output2="out2",
                 target=qua_vars[0],
             ),
-            dual_demod.full(
+            qua.dual_demod.full(
                 iw1=integration_weight_labels[2],
                 element_output1="out1",
                 iw2=integration_weight_labels[0],
@@ -1627,26 +1613,26 @@ class _InComplexChannel(Channel, ABC):
                     f"which is not a tuple of four QUA variables. Received {qua_vars=}"
                 )
         else:
-            qua_vars = [declare(fixed, size=num_segments) for _ in range(4)]
+            qua_vars = [qua.declare(qua.fixed, size=num_segments) for _ in range(4)]
 
         pulse_name_with_amp_scale = add_amplitude_scale_to_pulse_name(
             pulse_name, amplitude_scale
         )
 
         integration_weight_labels = list(pulse.integration_weights_mapping)
-        measure(
+        qua.measure(
             pulse_name_with_amp_scale,
             self.name,
-            demod.accumulated(
+            qua.demod.accumulated(
                 integration_weight_labels[0], qua_vars[0], segment_length, "out1"
             ),
-            demod.accumulated(
+            qua.demod.accumulated(
                 integration_weight_labels[1], qua_vars[1], segment_length, "out2"
             ),
-            demod.accumulated(
+            qua.demod.accumulated(
                 integration_weight_labels[2], qua_vars[2], segment_length, "out1"
             ),
-            demod.accumulated(
+            qua.demod.accumulated(
                 integration_weight_labels[0], qua_vars[3], segment_length, "out2"
             ),
             adc_stream=stream,
@@ -1713,26 +1699,26 @@ class _InComplexChannel(Channel, ABC):
                     f"which is not a tuple of four QUA variables. Received {qua_vars=}"
                 )
         else:
-            qua_vars = [declare(fixed, size=num_segments) for _ in range(4)]
+            qua_vars = [qua.declare(qua.fixed, size=num_segments) for _ in range(4)]
 
         pulse_name_with_amp_scale = add_amplitude_scale_to_pulse_name(
             pulse_name, amplitude_scale
         )
 
         integration_weight_labels = list(pulse.integration_weights_mapping)
-        measure(
+        qua.measure(
             pulse_name_with_amp_scale,
             self.name,
-            demod.sliced(
+            qua.demod.sliced(
                 integration_weight_labels[0], qua_vars[0], segment_length, "out1"
             ),
-            demod.sliced(
+            qua.demod.sliced(
                 integration_weight_labels[1], qua_vars[1], segment_length, "out2"
             ),
-            demod.sliced(
+            qua.demod.sliced(
                 integration_weight_labels[2], qua_vars[2], segment_length, "out1"
             ),
-            demod.sliced(
+            qua.demod.sliced(
                 integration_weight_labels[0], qua_vars[3], segment_length, "out2"
             ),
             adc_stream=stream,

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -441,8 +441,7 @@ class Channel(QuamComponent, ABC):
 
         Args:
             pulse_name (str): The name of the pulse to play. Should be registered in
-                `self.operations`. Can also be a ``ramp(slope)`` object from
-                ``qm.qua``, in which case validation is skipped automatically.
+                `self.operations`.
             amplitude_scale (Optional[Union[ScalarFloat, Sequence[ScalarFloat]]]):
                 Amplitude scale of the pulse. Can be either a (qua) float, or a list of
                 (qua) floats. If None, the pulse is played without amplitude scaling.
@@ -450,7 +449,7 @@ class Channel(QuamComponent, ABC):
                 clock cycle (4ns). If not provided, the default pulse duration will be
                 used. It is possible to dynamically change the duration of both constant
                 and arbitrary pulses. Arbitrary pulses can only be stretched, not
-                compressed. Required when ``pulse_name`` is a ``ramp(slope)`` object.
+                compressed.
             chirp (Union[(list[int], str), (int, str)]): Allows to perform
                 piecewise linear sweep of the element's intermediate
                 frequency in time. Input should be a tuple, with the 1st
@@ -472,30 +471,13 @@ class Channel(QuamComponent, ABC):
                 handle can be retrieved with
                 `qm._results.JobResults.get` with the same ``label``.
             validate (bool): If True (default), validate that the pulse is registered
-                in Channel.operations. Automatically set to False when
-                ``pulse_name`` is a ``ramp(slope)`` object.
+                in Channel.operations.
 
         Note:
             The `element` argument from `qm.qua.play()`is not needed, as it is
             automatically set to `self.name`.
 
         """
-        from qm.grpc.qua import QuaProgramRampPulse
-
-        if isinstance(pulse_name, QuaProgramRampPulse):
-            qua.play(
-                pulse=pulse_name,
-                element=self.name,
-                duration=duration,
-                condition=condition,
-                chirp=chirp,
-                truncate=truncate,
-                timestamp_stream=timestamp_stream,
-                continue_chirp=continue_chirp,
-                target=target,
-            )
-            return
-
         if validate and pulse_name not in self.operations:
             raise KeyError(
                 f"Operation '{pulse_name}' not found in channel '{self.name}'"

--- a/tests/components/channels/test_IQ_channel.py
+++ b/tests/components/channels/test_IQ_channel.py
@@ -4,7 +4,7 @@ from quam.components.ports.analog_outputs import OPXPlusAnalogOutputPort
 
 
 def test_IQ_channel_set_dc_offset(mocker):
-    mocker.patch("quam.components.channels.set_dc_offset")
+    mocker.patch("qm.qua.set_dc_offset")
 
     channel = IQChannel(
         id="channel",
@@ -21,9 +21,9 @@ def test_IQ_channel_set_dc_offset(mocker):
 
     channel.set_dc_offset(0.5, "I")
 
-    from quam.components.channels import set_dc_offset
+    import qm.qua
 
-    set_dc_offset.assert_called_once_with(
+    qm.qua.set_dc_offset.assert_called_once_with(
         element="channel", element_input="I", offset=0.5
     )
 

--- a/tests/components/channels/test_channel.py
+++ b/tests/components/channels/test_channel.py
@@ -2,24 +2,24 @@ from quam.components.channels import Channel
 
 
 def test_channel_frame_rotation_2pi(mocker):
-    mocker.patch("quam.components.channels.frame_rotation_2pi")
+    mocker.patch("qm.qua.frame_rotation_2pi")
 
     channel = Channel(id="channel")
 
     channel.frame_rotation_2pi(0.5)
 
-    from quam.components.channels import frame_rotation_2pi
+    import qm.qua
 
-    frame_rotation_2pi.assert_called_once_with(0.5, "channel")
+    qm.qua.frame_rotation_2pi.assert_called_once_with(0.5, "channel")
 
 
 def test_channel_update_frequency(mocker):
-    mocker.patch("quam.components.channels.update_frequency")
+    mocker.patch("qm.qua.update_frequency")
 
     channel = Channel(id="channel")
 
     channel.update_frequency(100e6)
 
-    from quam.components.channels import update_frequency
+    import qm.qua
 
-    update_frequency.assert_called_once_with("channel", 100e6, "Hz", False)
+    qm.qua.update_frequency.assert_called_once_with("channel", 100e6, "Hz", False)

--- a/tests/components/channels/test_channel_ramp.py
+++ b/tests/components/channels/test_channel_ramp.py
@@ -4,15 +4,14 @@ from qm import qua
 from qm.qua import ramp
 from quam.components.channels import Channel, SingleChannel
 
-
 # ---------------------------------------------------------------------------
 # Channel.ramp()
 # ---------------------------------------------------------------------------
 
 
 def test_channel_ramp_calls_play(mocker):
-    mock_play = mocker.patch("quam.components.channels.play")
-    mock_qua_ramp = mocker.patch("quam.components.channels.qua_ramp")
+    mock_play = mocker.patch("qm.qua.play")
+    mock_qua_ramp = mocker.patch("qm.qua.ramp")
     mock_qua_ramp.return_value = "ramp_obj"
 
     channel = Channel(id="test_channel")
@@ -35,7 +34,7 @@ def test_channel_ramp_inside_program():
 
 
 def test_channel_ramp_to_zero_calls_qua(mocker):
-    mock_ramp_to_zero = mocker.patch("quam.components.channels.qua_ramp_to_zero")
+    mock_ramp_to_zero = mocker.patch("qm.qua.ramp_to_zero")
 
     channel = Channel(id="test_channel")
     channel.ramp_to_zero()
@@ -44,7 +43,7 @@ def test_channel_ramp_to_zero_calls_qua(mocker):
 
 
 def test_channel_ramp_to_zero_with_duration(mocker):
-    mock_ramp_to_zero = mocker.patch("quam.components.channels.qua_ramp_to_zero")
+    mock_ramp_to_zero = mocker.patch("qm.qua.ramp_to_zero")
 
     channel = Channel(id="test_channel")
     channel.ramp_to_zero(duration=500)
@@ -65,7 +64,7 @@ def test_channel_ramp_to_zero_inside_program():
 
 
 def test_play_with_ramp_object_skips_validation(mocker):
-    mock_play = mocker.patch("quam.components.channels.play")
+    mock_play = mocker.patch("qm.qua.play")
     ramp_obj = ramp(0.0001)
 
     channel = Channel(id="test_channel")
@@ -101,7 +100,7 @@ def test_play_with_string_still_validates():
 
 def test_play_with_ramp_object_no_validate_false_needed(mocker):
     """Previously required validate=False — now works without it."""
-    mock_play = mocker.patch("quam.components.channels.play")
+    mock_play = mocker.patch("qm.qua.play")
     ramp_obj = ramp(0.0005)
 
     channel = Channel(id="test_channel")

--- a/tests/components/channels/test_channel_ramp.py
+++ b/tests/components/channels/test_channel_ramp.py
@@ -1,7 +1,6 @@
 import pytest
 
 from qm import qua
-from qm.qua import ramp
 from quam.components.channels import Channel, SingleChannel
 
 # ---------------------------------------------------------------------------
@@ -58,53 +57,8 @@ def test_channel_ramp_to_zero_inside_program():
         channel.ramp_to_zero()
 
 
-# ---------------------------------------------------------------------------
-# Channel.play() accepts ramp() object without validate=False
-# ---------------------------------------------------------------------------
-
-
-def test_play_with_ramp_object_skips_validation(mocker):
-    mock_play = mocker.patch("qm.qua.play")
-    ramp_obj = ramp(0.0001)
-
-    channel = Channel(id="test_channel")
-    # Should not raise KeyError even though "ramp_obj" is not in operations
-    channel.play(ramp_obj, duration=1000)
-
-    mock_play.assert_called_once_with(
-        pulse=ramp_obj,
-        element="test_channel",
-        duration=1000,
-        condition=None,
-        chirp=None,
-        truncate=None,
-        timestamp_stream=None,
-        continue_chirp=False,
-        target="",
-    )
-
-
-def test_play_with_ramp_object_inside_program():
-    channel = Channel(id="test_channel")
-
-    with qua.program() as prog:
-        channel.play(ramp(0.0001), duration=1000)
-
-
 def test_play_with_string_still_validates():
     channel = Channel(id="test_channel")
 
     with pytest.raises(KeyError, match="not found in channel"):
         channel.play("nonexistent_pulse")
-
-
-def test_play_with_ramp_object_no_validate_false_needed(mocker):
-    """Previously required validate=False — now works without it."""
-    mock_play = mocker.patch("qm.qua.play")
-    ramp_obj = ramp(0.0005)
-
-    channel = Channel(id="test_channel")
-    # validate=True is the default — must not raise
-    channel.play(ramp_obj, duration=500)
-
-    assert mock_play.called

--- a/tests/components/channels/test_channel_ramp.py
+++ b/tests/components/channels/test_channel_ramp.py
@@ -1,0 +1,111 @@
+import pytest
+
+from qm import qua
+from qm.qua import ramp
+from quam.components.channels import Channel, SingleChannel
+
+
+# ---------------------------------------------------------------------------
+# Channel.ramp()
+# ---------------------------------------------------------------------------
+
+
+def test_channel_ramp_calls_play(mocker):
+    mock_play = mocker.patch("quam.components.channels.play")
+    mock_qua_ramp = mocker.patch("quam.components.channels.qua_ramp")
+    mock_qua_ramp.return_value = "ramp_obj"
+
+    channel = Channel(id="test_channel")
+    channel.ramp(slope=0.0001, duration=1000)
+
+    mock_qua_ramp.assert_called_once_with(0.0001)
+    mock_play.assert_called_once_with("ramp_obj", "test_channel", duration=1000)
+
+
+def test_channel_ramp_inside_program():
+    channel = Channel(id="test_channel")
+
+    with qua.program() as prog:
+        channel.ramp(slope=0.0001, duration=1000)
+
+
+# ---------------------------------------------------------------------------
+# Channel.ramp_to_zero()
+# ---------------------------------------------------------------------------
+
+
+def test_channel_ramp_to_zero_calls_qua(mocker):
+    mock_ramp_to_zero = mocker.patch("quam.components.channels.qua_ramp_to_zero")
+
+    channel = Channel(id="test_channel")
+    channel.ramp_to_zero()
+
+    mock_ramp_to_zero.assert_called_once_with("test_channel", duration=None)
+
+
+def test_channel_ramp_to_zero_with_duration(mocker):
+    mock_ramp_to_zero = mocker.patch("quam.components.channels.qua_ramp_to_zero")
+
+    channel = Channel(id="test_channel")
+    channel.ramp_to_zero(duration=500)
+
+    mock_ramp_to_zero.assert_called_once_with("test_channel", duration=500)
+
+
+def test_channel_ramp_to_zero_inside_program():
+    channel = Channel(id="test_channel")
+
+    with qua.program() as prog:
+        channel.ramp_to_zero()
+
+
+# ---------------------------------------------------------------------------
+# Channel.play() accepts ramp() object without validate=False
+# ---------------------------------------------------------------------------
+
+
+def test_play_with_ramp_object_skips_validation(mocker):
+    mock_play = mocker.patch("quam.components.channels.play")
+    ramp_obj = ramp(0.0001)
+
+    channel = Channel(id="test_channel")
+    # Should not raise KeyError even though "ramp_obj" is not in operations
+    channel.play(ramp_obj, duration=1000)
+
+    mock_play.assert_called_once_with(
+        pulse=ramp_obj,
+        element="test_channel",
+        duration=1000,
+        condition=None,
+        chirp=None,
+        truncate=None,
+        timestamp_stream=None,
+        continue_chirp=False,
+        target="",
+    )
+
+
+def test_play_with_ramp_object_inside_program():
+    channel = Channel(id="test_channel")
+
+    with qua.program() as prog:
+        channel.play(ramp(0.0001), duration=1000)
+
+
+def test_play_with_string_still_validates():
+    channel = Channel(id="test_channel")
+
+    with pytest.raises(KeyError, match="not found in channel"):
+        channel.play("nonexistent_pulse")
+
+
+def test_play_with_ramp_object_no_validate_false_needed(mocker):
+    """Previously required validate=False — now works without it."""
+    mock_play = mocker.patch("quam.components.channels.play")
+    ramp_obj = ramp(0.0005)
+
+    channel = Channel(id="test_channel")
+    # validate=True is the default — must not raise
+    channel.play(ramp_obj, duration=500)
+
+    assert mock_play.called

--- a/tests/components/channels/test_in_out_IQ_channel.py
+++ b/tests/components/channels/test_in_out_IQ_channel.py
@@ -260,8 +260,8 @@ def test_channel_measure(mocker):
         amplitude=0.1, length=1000
     )
 
-    mocker.patch("quam.components.channels.declare", return_value=1)
-    mocker.patch("quam.components.channels.measure", return_value=1)
+    mocker.patch("qm.qua.declare", return_value=1)
+    mocker.patch("qm.qua.measure", return_value=1)
     result = readout_resonator.measure("readout")
     assert result == (1, 1)
 

--- a/tests/components/channels/test_single_channel.py
+++ b/tests/components/channels/test_single_channel.py
@@ -125,14 +125,14 @@ def test_single_channel_offset_quam(qua_config):
 
 
 def test_single_channel_set_dc_offset(mocker):
-    mocker.patch("quam.components.channels.set_dc_offset")
+    mocker.patch("qm.qua.set_dc_offset")
 
     channel = SingleChannel(id="channel", opx_output=("con1", 1))
     channel.set_dc_offset(0.5)
 
-    from quam.components.channels import set_dc_offset
+    import qm.qua
 
-    set_dc_offset.assert_called_once_with(
+    qm.qua.set_dc_offset.assert_called_once_with(
         element="channel", element_input="single", offset=0.5
     )
 

--- a/tests/components/pulses/test_pulses.py
+++ b/tests/components/pulses/test_pulses.py
@@ -242,7 +242,7 @@ def test_pulse_play(mocker):
     pulse = pulses.SquarePulse(length=60, amplitude=0)
     channel.operations["pulse"] = pulse
 
-    mock_play = mocker.patch("quam.components.channels.play")
+    mock_play = mocker.patch("qm.qua.play")
     channel.play("pulse", duration=100)
     mock_play.assert_called_once_with(
         pulse="pulse",

--- a/tests/macros/test_pulse_macro.py
+++ b/tests/macros/test_pulse_macro.py
@@ -61,13 +61,13 @@ def test_pulse_macro_pulse_string(test_qubit, mocker):
     with pytest.raises(NoScopeFoundException):
         test_qubit.apply("test_pulse")
 
-    mocker.patch("quam.components.channels.play")
+    mocker.patch("qm.qua.play")
 
     test_qubit.apply("test_pulse")
 
-    from quam.components.channels import play
+    import qm.qua
 
-    play.assert_called_once()
+    qm.qua.play.assert_called_once()
 
 
 def test_pulse_macro_pulse_object_error(test_qubit):
@@ -91,10 +91,10 @@ def test_pulse_macro_pulse_reference(test_qubit, mocker):
 
     test_qubit.macros["pulse_macro"] = pulse_macro
 
-    mocker.patch("quam.components.channels.play")
+    mocker.patch("qm.qua.play")
 
     test_qubit.apply("pulse_macro")
 
-    from quam.components.channels import play
+    import qm.qua
 
-    play.assert_called_once()
+    qm.qua.play.assert_called_once()


### PR DESCRIPTION
- `Channel.ramp(slope, duration)`: dedicated method for playing linear voltage ramps; slope is in V/ns
- `Channel.ramp_to_zero(duration=None)`: wraps `qm.qua.ramp_to_zero`
- For IQ channels, `ramp()` applies the same ramp to both I and Q outputs together
- `Channel.play()` does **not** accept ramp objects; use `Channel.ramp()` instead

Fixes #187