### PR TITLE
Improve error messages for inferred frequency properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ All deprecated properties now show migration guidance with code examples. See [P
 
 ### Fixed
 
-- Improved error messages for inferred frequency properties (`inferred_RF_frequency`, `inferred_intermediate_frequency`, `inferred_LO_frequency`) in `_OutComplexChannel`: errors now clearly identify the specific field and whether it is `None` or an unresolved reference
+- Improved error messages for inferred frequency properties (`inferred_RF_frequency`, `inferred_intermediate_frequency`, `inferred_LO_frequency`) in `_OutComplexChannel` (`IQChannel` and `MWChannel`): errors now clearly identify the specific field and whether it is `None` or an unresolved reference
 - Fixed config version mismatch error handling:
   - Separated error handling for config-too-old vs package-too-old scenarios
   - Original version mismatch error was being masked by `ModuleNotFoundError` during migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All deprecated properties now show migration guidance with code examples. See [P
 
 ### Fixed
 
+- Improved error messages for inferred frequency properties (`inferred_RF_frequency`, `inferred_intermediate_frequency`, `inferred_LO_frequency`) in `_OutComplexChannel`: errors now clearly identify the specific field and whether it is `None` or an unresolved reference
 - Fixed config version mismatch error handling:
   - Separated error handling for config-too-old vs package-too-old scenarios
   - Original version mismatch error was being masked by `ModuleNotFoundError` during migration

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -1201,7 +1201,7 @@ class InSingleChannel(Channel):
 
 
 def _raise_inferred_freq_error(
-    freq_name: str, channel_name: str, field_name: str, value
+    freq_name: str, channel_name: str, field_name: str, value: Any
 ) -> None:
     """Raise an AttributeError with a clear message when a frequency field is invalid.
 
@@ -1211,13 +1211,15 @@ def _raise_inferred_freq_error(
         field_name: Name of the field that has the invalid value.
         value: The invalid value.
     """
-    prefix = f"Cannot infer {freq_name} for channel '{channel_name}': '{field_name}'"
+    prefix = f"Cannot infer {freq_name} for channel '{channel_name}'"
     if value is None:
-        raise AttributeError(f"{prefix}' is None")
+        raise AttributeError(f"{prefix}: '{field_name}' is None")
     if str_ref.is_reference(value):
-        raise AttributeError(f"{prefix}' is an unresolved reference: '{value}'")
+        raise AttributeError(
+            f"{prefix}: '{field_name}' is an unresolved reference: '{value}'"
+        )
     raise AttributeError(
-        f"{prefix}' has unexpected type {type(value).__name__}: {value!r}"
+        f"{prefix}: '{field_name}' has unexpected type {type(value).__name__}: {value!r}"
     )
 
 

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -1200,6 +1200,27 @@ class InSingleChannel(Channel):
         return times, counts
 
 
+def _raise_inferred_freq_error(
+    freq_name: str, channel_name: str, field_name: str, value
+) -> None:
+    """Raise an AttributeError with a clear message when a frequency field is invalid.
+
+    Args:
+        freq_name: Name of the frequency being inferred (e.g. "RF frequency").
+        channel_name: Name of the channel for context.
+        field_name: Name of the field that has the invalid value.
+        value: The invalid value.
+    """
+    prefix = f"Cannot infer {freq_name} for channel '{channel_name}': '{field_name}'"
+    if value is None:
+        raise AttributeError(f"{prefix}' is None")
+    if str_ref.is_reference(value):
+        raise AttributeError(f"{prefix}' is an unresolved reference: '{value}'")
+    raise AttributeError(
+        f"{prefix}' has unexpected type {type(value).__name__}: {value!r}"
+    )
+
+
 @quam_dataclass
 class _OutComplexChannel(Channel, ABC):
     """Base class for IQ and MW output channels."""
@@ -1217,14 +1238,10 @@ class _OutComplexChannel(Channel, ABC):
         """
         name = getattr(self, "name", self.__class__.__name__)
         if not isinstance(self.LO_frequency, (float, int)):
-            raise AttributeError(
-                f"Error inferring RF frequency for channel {name}: "
-                f"LO_frequency is not a number: {self.LO_frequency}"
-            )
+            _raise_inferred_freq_error("RF frequency", name, "LO_frequency", self.LO_frequency)
         if not isinstance(self.intermediate_frequency, (float, int)):
-            raise AttributeError(
-                f"Error inferring RF frequency for channel {name}: "
-                f"intermediate_frequency is not a number: {self.intermediate_frequency}"
+            _raise_inferred_freq_error(
+                "RF frequency", name, "intermediate_frequency", self.intermediate_frequency
             )
         return self.LO_frequency + self.intermediate_frequency
 
@@ -1240,14 +1257,12 @@ class _OutComplexChannel(Channel, ABC):
         """
         name = getattr(self, "name", self.__class__.__name__)
         if not isinstance(self.LO_frequency, (float, int)):
-            raise AttributeError(
-                f"Error inferring intermediate frequency for channel {name}: "
-                f"LO_frequency is not a number: {self.LO_frequency}"
+            _raise_inferred_freq_error(
+                "intermediate frequency", name, "LO_frequency", self.LO_frequency
             )
         if not isinstance(self.RF_frequency, (float, int)):
-            raise AttributeError(
-                f"Error inferring intermediate frequency for channel {name}: "
-                f"RF_frequency is not a number: {self.RF_frequency}"
+            _raise_inferred_freq_error(
+                "intermediate frequency", name, "RF_frequency", self.RF_frequency
             )
         return self.RF_frequency - self.LO_frequency
 
@@ -1262,14 +1277,12 @@ class _OutComplexChannel(Channel, ABC):
         """
         name = getattr(self, "name", self.__class__.__name__)
         if not isinstance(self.RF_frequency, (float, int)):
-            raise AttributeError(
-                f"Error inferring LO frequency for channel {name}: "
-                f"RF_frequency is not a number: {self.RF_frequency}"
+            _raise_inferred_freq_error(
+                "LO frequency", name, "RF_frequency", self.RF_frequency
             )
         if not isinstance(self.intermediate_frequency, (float, int)):
-            raise AttributeError(
-                f"Error inferring LO frequency for channel {name}: "
-                f"intermediate_frequency is not a number: {self.intermediate_frequency}"
+            _raise_inferred_freq_error(
+                "LO frequency", name, "intermediate_frequency", self.intermediate_frequency
             )
         return self.RF_frequency - self.intermediate_frequency
 

--- a/tests/components/channels/test_IQ_channel.py
+++ b/tests/components/channels/test_IQ_channel.py
@@ -91,6 +91,179 @@ def test_IQ_channel_inferred_LO_frequency():
         channel.inferred_LO_frequency
 
 
+# --- inferred_RF_frequency error message tests ---
+
+
+def test_inferred_RF_frequency_error_LO_is_none():
+    channel = IQChannel(
+        id="my_channel",
+        opx_output_I=("con1", 1),
+        opx_output_Q=("con1", 2),
+        frequency_converter_up=None,
+        LO_frequency=None,
+        intermediate_frequency=100e6,
+    )
+    with pytest.raises(AttributeError, match="LO_frequency.*None"):
+        channel.inferred_RF_frequency
+
+
+def test_inferred_RF_frequency_error_IF_is_none():
+    channel = IQChannel(
+        id="my_channel",
+        opx_output_I=("con1", 1),
+        opx_output_Q=("con1", 2),
+        frequency_converter_up=None,
+        LO_frequency=5e9,
+        intermediate_frequency=None,
+    )
+    with pytest.raises(AttributeError, match="intermediate_frequency.*None"):
+        channel.inferred_RF_frequency
+
+
+def test_inferred_RF_frequency_error_LO_is_unresolved_reference():
+    channel = IQChannel(
+        id="my_channel",
+        opx_output_I=("con1", 1),
+        opx_output_Q=("con1", 2),
+        frequency_converter_up=None,
+        LO_frequency="#./nonexistent_attr",
+        intermediate_frequency=100e6,
+    )
+    with pytest.raises(AttributeError, match="LO_frequency.*unresolved reference"):
+        channel.inferred_RF_frequency
+
+
+def test_inferred_RF_frequency_error_IF_is_unresolved_reference():
+    channel = IQChannel(
+        id="my_channel",
+        opx_output_I=("con1", 1),
+        opx_output_Q=("con1", 2),
+        frequency_converter_up=None,
+        LO_frequency=5e9,
+        intermediate_frequency="#./nonexistent_attr",
+    )
+    with pytest.raises(AttributeError, match="intermediate_frequency.*unresolved reference"):
+        channel.inferred_RF_frequency
+
+
+# --- inferred_intermediate_frequency error message tests ---
+
+
+def test_inferred_intermediate_frequency_error_LO_is_none():
+    channel = IQChannel(
+        id="my_channel",
+        opx_output_I=("con1", 1),
+        opx_output_Q=("con1", 2),
+        frequency_converter_up=None,
+        intermediate_frequency="#./inferred_intermediate_frequency",
+        LO_frequency=None,
+        RF_frequency=5.2e9,
+    )
+    with pytest.raises(AttributeError, match="LO_frequency.*None"):
+        channel.inferred_intermediate_frequency
+
+
+def test_inferred_intermediate_frequency_error_RF_is_none():
+    channel = IQChannel(
+        id="my_channel",
+        opx_output_I=("con1", 1),
+        opx_output_Q=("con1", 2),
+        frequency_converter_up=None,
+        intermediate_frequency="#./inferred_intermediate_frequency",
+        LO_frequency=5.1e9,
+        RF_frequency=None,
+    )
+    with pytest.raises(AttributeError, match="RF_frequency.*None"):
+        channel.inferred_intermediate_frequency
+
+
+def test_inferred_intermediate_frequency_error_LO_is_unresolved_reference():
+    channel = IQChannel(
+        id="my_channel",
+        opx_output_I=("con1", 1),
+        opx_output_Q=("con1", 2),
+        frequency_converter_up=None,
+        intermediate_frequency="#./inferred_intermediate_frequency",
+        LO_frequency="#./nonexistent_attr",
+        RF_frequency=5.2e9,
+    )
+    with pytest.raises(AttributeError, match="LO_frequency.*unresolved reference"):
+        channel.inferred_intermediate_frequency
+
+
+def test_inferred_intermediate_frequency_error_RF_is_unresolved_reference():
+    channel = IQChannel(
+        id="my_channel",
+        opx_output_I=("con1", 1),
+        opx_output_Q=("con1", 2),
+        frequency_converter_up=None,
+        intermediate_frequency="#./inferred_intermediate_frequency",
+        LO_frequency=5.1e9,
+        RF_frequency="#./nonexistent_attr",
+    )
+    with pytest.raises(AttributeError, match="RF_frequency.*unresolved reference"):
+        channel.inferred_intermediate_frequency
+
+
+# --- inferred_LO_frequency error message tests ---
+
+
+def test_inferred_LO_frequency_error_RF_is_none():
+    channel = IQChannel(
+        id="my_channel",
+        opx_output_I=("con1", 1),
+        opx_output_Q=("con1", 2),
+        frequency_converter_up=None,
+        intermediate_frequency=100e6,
+        LO_frequency="#./inferred_LO_frequency",
+        RF_frequency=None,
+    )
+    with pytest.raises(AttributeError, match="RF_frequency.*None"):
+        channel.inferred_LO_frequency
+
+
+def test_inferred_LO_frequency_error_IF_is_none():
+    channel = IQChannel(
+        id="my_channel",
+        opx_output_I=("con1", 1),
+        opx_output_Q=("con1", 2),
+        frequency_converter_up=None,
+        intermediate_frequency=None,
+        LO_frequency="#./inferred_LO_frequency",
+        RF_frequency=5.2e9,
+    )
+    with pytest.raises(AttributeError, match="intermediate_frequency.*None"):
+        channel.inferred_LO_frequency
+
+
+def test_inferred_LO_frequency_error_RF_is_unresolved_reference():
+    channel = IQChannel(
+        id="my_channel",
+        opx_output_I=("con1", 1),
+        opx_output_Q=("con1", 2),
+        frequency_converter_up=None,
+        intermediate_frequency=100e6,
+        LO_frequency="#./inferred_LO_frequency",
+        RF_frequency="#./nonexistent_attr",
+    )
+    with pytest.raises(AttributeError, match="RF_frequency.*unresolved reference"):
+        channel.inferred_LO_frequency
+
+
+def test_inferred_LO_frequency_error_IF_is_unresolved_reference():
+    channel = IQChannel(
+        id="my_channel",
+        opx_output_I=("con1", 1),
+        opx_output_Q=("con1", 2),
+        frequency_converter_up=None,
+        intermediate_frequency="#./nonexistent_attr",
+        LO_frequency="#./inferred_LO_frequency",
+        RF_frequency=5.2e9,
+    )
+    with pytest.raises(AttributeError, match="intermediate_frequency.*unresolved reference"):
+        channel.inferred_LO_frequency
+
+
 def test_generate_config(qua_config):
     channel = IQChannel(
         id="out_channel",

--- a/tests/components/channels/test_IQ_channel.py
+++ b/tests/components/channels/test_IQ_channel.py
@@ -91,6 +91,98 @@ def test_IQ_channel_inferred_LO_frequency():
         channel.inferred_LO_frequency
 
 
+@pytest.mark.parametrize(
+    "channel_kwargs, property_name, match",
+    [
+        # inferred_RF_frequency
+        pytest.param(
+            {"LO_frequency": None, "intermediate_frequency": 100e6},
+            "inferred_RF_frequency",
+            "LO_frequency.*None",
+            id="RF-LO_is_None",
+        ),
+        pytest.param(
+            {"LO_frequency": 5e9, "intermediate_frequency": None},
+            "inferred_RF_frequency",
+            "intermediate_frequency.*None",
+            id="RF-IF_is_None",
+        ),
+        pytest.param(
+            {"LO_frequency": "#./nonexistent_attr", "intermediate_frequency": 100e6},
+            "inferred_RF_frequency",
+            "LO_frequency.*unresolved reference",
+            id="RF-LO_is_unresolved_ref",
+        ),
+        pytest.param(
+            {"LO_frequency": 5e9, "intermediate_frequency": "#./nonexistent_attr"},
+            "inferred_RF_frequency",
+            "intermediate_frequency.*unresolved reference",
+            id="RF-IF_is_unresolved_ref",
+        ),
+        # inferred_intermediate_frequency
+        pytest.param(
+            {"LO_frequency": None, "RF_frequency": 5.2e9},
+            "inferred_intermediate_frequency",
+            "LO_frequency.*None",
+            id="IF-LO_is_None",
+        ),
+        pytest.param(
+            {"LO_frequency": 5.1e9, "RF_frequency": None},
+            "inferred_intermediate_frequency",
+            "RF_frequency.*None",
+            id="IF-RF_is_None",
+        ),
+        pytest.param(
+            {"LO_frequency": "#./nonexistent_attr", "RF_frequency": 5.2e9},
+            "inferred_intermediate_frequency",
+            "LO_frequency.*unresolved reference",
+            id="IF-LO_is_unresolved_ref",
+        ),
+        pytest.param(
+            {"LO_frequency": 5.1e9, "RF_frequency": "#./nonexistent_attr"},
+            "inferred_intermediate_frequency",
+            "RF_frequency.*unresolved reference",
+            id="IF-RF_is_unresolved_ref",
+        ),
+        # inferred_LO_frequency
+        pytest.param(
+            {"RF_frequency": None, "intermediate_frequency": 100e6},
+            "inferred_LO_frequency",
+            "RF_frequency.*None",
+            id="LO-RF_is_None",
+        ),
+        pytest.param(
+            {"RF_frequency": 5.2e9, "intermediate_frequency": None},
+            "inferred_LO_frequency",
+            "intermediate_frequency.*None",
+            id="LO-IF_is_None",
+        ),
+        pytest.param(
+            {"RF_frequency": "#./nonexistent_attr", "intermediate_frequency": 100e6},
+            "inferred_LO_frequency",
+            "RF_frequency.*unresolved reference",
+            id="LO-RF_is_unresolved_ref",
+        ),
+        pytest.param(
+            {"RF_frequency": 5.2e9, "intermediate_frequency": "#./nonexistent_attr"},
+            "inferred_LO_frequency",
+            "intermediate_frequency.*unresolved reference",
+            id="LO-IF_is_unresolved_ref",
+        ),
+    ],
+)
+def test_inferred_frequency_error_messages(channel_kwargs, property_name, match):
+    channel = IQChannel(
+        id="my_channel",
+        opx_output_I=("con1", 1),
+        opx_output_Q=("con1", 2),
+        frequency_converter_up=None,
+        **channel_kwargs,
+    )
+    with pytest.raises(AttributeError, match=match):
+        getattr(channel, property_name)
+
+
 def test_generate_config(qua_config):
     channel = IQChannel(
         id="out_channel",


### PR DESCRIPTION
## Summary

- Adds `_raise_inferred_freq_error` helper in `_OutComplexChannel` to produce consistent, descriptive `AttributeError` messages when `inferred_RF_frequency`, `inferred_intermediate_frequency`, or `inferred_LO_frequency` cannot be computed
- Error messages now distinguish between `None` values and unresolved references, naming the specific field that caused the failure
- Adds a parametrized test covering all 12 error cases (3 properties × 4 invalid-value scenarios)

## Test plan

- [ ] `pytest tests/components/channels/test_IQ_channel.py -v` — all existing and new parametrized tests pass