### PR TITLE
Clarify deprecated channel properties will be removed in v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,12 @@
 
 ### Deprecated
 
-- `SingleChannel.opx_output_offset` - Use `Port.offset` instead
-- `SingleChannel.filter_fir_taps` - Use `Port.feedforward_filter` instead
-- `SingleChannel.filter_iir_taps` - Use `Port.feedback_filter` instead
-- `DigitalOutputChannel.shareable` - Use `Port.shareable` instead
-- `DigitalOutputChannel.inverted` - Use `Port.inverted` instead
+- `SingleChannel.opx_output_offset` - Use `Port.offset` instead. Will be removed in v0.6.0.
+- `SingleChannel.filter_fir_taps` - Use `Port.feedforward_filter` instead. Will be removed in v0.6.0.
+- `SingleChannel.filter_iir_taps` - Use `Port.feedback_filter` instead. Will be removed in v0.6.0.
+- `DigitalOutputChannel.shareable` - Use `Port.shareable` instead. Will be removed in v0.6.0.
+- `DigitalOutputChannel.inverted` - Use `Port.inverted` instead. Will be removed in v0.6.0.
+- All channel-level port offset properties (`opx_output_offset_I/Q`, `opx_input_offset`, etc.) - Use `Port.offset` instead. Will be removed in v0.6.0.
 
 All deprecated properties now show migration guidance with code examples. See [Port documentation](https://qua-platform.github.io/quam/components/channel-ports/) for migration details.
 

--- a/docs/components/channel-ports.md
+++ b/docs/components/channel-ports.md
@@ -256,7 +256,7 @@ Ports support crosstalk compensation, FIR/IIR filters (OPX+), and exponential fi
 
 - **Use port references**: Always use `port.get_reference()` instead of passing port objects directly
 - **Centralized management**: Create all ports before channels for better organization
-- **Configure properties on ports**: Set properties like `offset`, `shareable`, `inverted`, and filters directly on Port objects, not on channels. Channel-level port properties are deprecated and will be removed in a future version.
+- **Configure properties on ports**: Set properties like `offset`, `shareable`, `inverted`, and filters directly on Port objects, not on channels. Channel-level port properties are deprecated and will be removed in v0.6.0.
 - **Avoid deprecated channel properties**: Do not use `opx_output_offset`, `opx_input_offset`, `filter_fir_taps`, `filter_iir_taps`, `shareable`, or `inverted` on channel objects. These emit deprecation warnings and will be removed.
 - **Port sharing**: Set `shareable=True` when multiple channels use the same port
 - **Choose the right type**: MW-FEM for microwave/RF, LF-FEM for high-rate baseband/IF
@@ -265,7 +265,7 @@ Ports support crosstalk compensation, FIR/IIR filters (OPX+), and exponential fi
 
 /// details | Deprecated Channel Properties
 type: warning
-As of QUAM v0.5.0, setting port properties on channels is deprecated. Runtime warnings are emitted to help you migrate your code. See the [Channels Migration Guide](channels.md#migrating-from-channel-level-port-properties) for detailed examples.
+As of QUAM v0.5.0, setting port properties on channels is deprecated and will be removed in v0.6.0. Runtime warnings are emitted to help you migrate your code. See the [Channels Migration Guide](channels.md#migrating-from-channel-level-port-properties) for detailed examples.
 ///
 
 ### Quick Migration Guide

--- a/docs/components/channels.md
+++ b/docs/components/channels.md
@@ -48,7 +48,7 @@ IQ_channel = IQChannel(
 type: warning
 Some properties such as `opx_output_offset`, `opx_input_offset`, `filter_fir_taps`, `filter_iir_taps`, `shareable`, and `inverted` are currently available as channel attributes for backwards compatibility. However, these properties belong to ports and should be configured through explicit [Port][quam.components.ports.BasePort] objects.
 
-**These properties are deprecated and will be removed in a future version.** Runtime deprecation warnings are now emitted when these properties are used, providing migration guidance. See the [Migration Guide](#migrating-from-channel-level-port-properties) below for details on how to update your code.
+**These properties are deprecated and will be removed in v0.6.0.** Runtime deprecation warnings are now emitted when these properties are used, providing migration guidance. See the [Migration Guide](#migrating-from-channel-level-port-properties) below for details on how to update your code.
 ///
 
 For more advanced port management, including port containers, port references, and hardware-specific configurations (LF-FEM, MW-FEM, OPX+), see the [Channel Ports](channel-ports.md) documentation.
@@ -103,7 +103,7 @@ IQ_channel = IQChannel(opx_output_I=port_I, opx_output_Q=port_Q)
 **Deprecated Approach** - Setting offset on channel (emits deprecation warning):
 
 ```python
-# Still works but will be removed in a future version
+# Still works but will be removed in v0.6.0
 channel = SingleChannel(opx_output=("con1", 1), opx_output_offset=0.15)
 IQ_channel = IQChannel(
     opx_output_I=("con1", 2),
@@ -342,7 +342,7 @@ Additional information on time tagging can be found in the [Time Tagging QUA doc
 
 ## Migrating from Channel-Level Port Properties
 
-As of QUAM v0.5.0, port-related properties on channels are deprecated. This section provides guidance on migrating your code to use explicit Port objects instead.
+As of QUAM v0.5.0, port-related properties on channels are deprecated and will be removed in v0.6.0. This section provides guidance on migrating your code to use explicit Port objects instead.
 
 ### Why Migrate?
 
@@ -351,7 +351,7 @@ Port properties such as `opx_output_offset`, `filter_fir_taps`, `shareable`, and
 - **Clarifies ownership**: Properties are configured where they belong
 - **Enables port sharing**: Multiple channels can reference the same configured port
 - **Centralizes configuration**: Port containers provide unified port management
-- **Prepares for future**: Channel-level properties will be removed in a future version
+- **Prepares for future**: Channel-level properties will be removed in v0.6.0
 
 ### Migration Examples
 

--- a/quam/components/channels.py
+++ b/quam/components/channels.py
@@ -122,7 +122,7 @@ def _create_port_property_deprecation_message(
     # Build migration message
     message = (
         f"{channel_class}.{property_name} is deprecated and will be removed "
-        f"in a future version. Port properties should be configured on "
+        f"in v0.6.0. Port properties should be configured on "
         f"dedicated Port objects.\n\n"
         f"Migration: Create an explicit port instead:\n"
         f"  from quam.components.ports import OPXPlusAnalogOutputPort\n"
@@ -153,11 +153,11 @@ class DigitalOutputChannel(QuamComponent):
             QM instances.
             **Deprecated**: This property has been moved to Port objects. Use
             `OPXPlusDigitalOutputPort(shareable=...)` instead.
-            See [Port documentation](channel-ports.md) for details.
+            Will be removed in v0.6.0. See [Port documentation](channel-ports.md) for details.
         inverted (bool, deprecated): If True, the digital output is inverted.
             **Deprecated**: This property has been moved to Port objects. Use
             `OPXPlusDigitalOutputPort(inverted=...)` instead.
-            See [Port documentation](channel-ports.md) for details.
+            Will be removed in v0.6.0. See [Port documentation](channel-ports.md) for details.
     ."""
 
     opx_output: Union[Tuple[str, int], Tuple[str, int, int], DigitalOutputPort]
@@ -772,15 +772,15 @@ class SingleChannel(Channel):
         filter_fir_taps (List[float], deprecated): FIR filter taps for the output port.
             **Deprecated**: This property has been moved to Port objects. Use
             `OPXPlusAnalogOutputPort(feedforward_filter=...)` instead.
-            See [Port documentation](channel-ports.md) for details.
+            Will be removed in v0.6.0. See [Port documentation](channel-ports.md) for details.
         filter_iir_taps (List[float], deprecated): IIR filter taps for the output port.
             **Deprecated**: This property has been moved to Port objects. Use
             `OPXPlusAnalogOutputPort(feedback_filter=...)` instead.
-            See [Port documentation](channel-ports.md) for details.
+            Will be removed in v0.6.0. See [Port documentation](channel-ports.md) for details.
         opx_output_offset (float, deprecated): DC offset for the output port.
             **Deprecated**: This property has been moved to Port objects. Use
             `OPXPlusAnalogOutputPort(offset=...)` instead.
-            See [Port documentation](channel-ports.md) for details.
+            Will be removed in v0.6.0. See [Port documentation](channel-ports.md) for details.
         intermediate_frequency (float): Intermediate frequency of OPX output, default
             is None.
     """
@@ -889,7 +889,7 @@ class InSingleChannel(Channel):
         opx_input_offset (float, deprecated): DC offset for the input port.
             **Deprecated**: This property has been moved to Port objects. Use
             `OPXPlusAnalogInputPort(offset=...)` instead.
-            See [Port documentation](channel-ports.md) for details.
+            Will be removed in v0.6.0. See [Port documentation](channel-ports.md) for details.
         intermediate_frequency (float): Intermediate frequency of OPX input,
             default is None.
         time_of_flight (int): Round-trip signal duration in nanoseconds.
@@ -1330,11 +1330,11 @@ class IQChannel(_OutComplexChannel):
         opx_output_offset_I (float, deprecated): The offset of the I channel.
             **Deprecated**: This property has been moved to Port objects. Use
             `OPXPlusAnalogOutputPort(offset=...)` on the I port instead.
-            See [Port documentation](channel-ports.md) for details.
+            Will be removed in v0.6.0. See [Port documentation](channel-ports.md) for details.
         opx_output_offset_Q (float, deprecated): The offset of the Q channel.
             **Deprecated**: This property has been moved to Port objects. Use
             `OPXPlusAnalogOutputPort(offset=...)` on the Q port instead.
-            See [Port documentation](channel-ports.md) for details.
+            Will be removed in v0.6.0. See [Port documentation](channel-ports.md) for details.
         intermediate_frequency (float): Intermediate frequency of the mixer.
             Default is 0.0
         LO_frequency (float): Local oscillator frequency. Default is the LO frequency
@@ -1369,7 +1369,9 @@ class IQChannel(_OutComplexChannel):
     @property
     def rf_frequency(self):
         warnings.warn(
-            "rf_frequency is deprecated, use RF_frequency instead", DeprecationWarning
+            "rf_frequency is deprecated and will be removed in v0.6.0, "
+            "use RF_frequency instead",
+            DeprecationWarning,
         )
         return self.frequency_converter_up.LO_frequency + self.intermediate_frequency
 
@@ -1741,11 +1743,11 @@ class InIQChannel(_InComplexChannel):
         opx_input_offset_I (float, deprecated): The offset of the I channel.
             **Deprecated**: This property has been moved to Port objects. Use
             `OPXPlusAnalogInputPort(offset=...)` on the I port instead.
-            See [Port documentation](channel-ports.md) for details.
+            Will be removed in v0.6.0. See [Port documentation](channel-ports.md) for details.
         opx_input_offset_Q (float, deprecated): The offset of the Q channel.
             **Deprecated**: This property has been moved to Port objects. Use
             `OPXPlusAnalogInputPort(offset=...)` on the Q port instead.
-            See [Port documentation](channel-ports.md) for details.
+            Will be removed in v0.6.0. See [Port documentation](channel-ports.md) for details.
         frequency_converter_down (Optional[FrequencyConverter]): Frequency converter
             QUAM component for the IQ input port. Only needed for the old Octave.
         time_of_flight (int): Round-trip signal duration in nanoseconds.


### PR DESCRIPTION
## Summary

- Updates all deprecation messages in `channels.py` to say "will be removed in v0.6.0" instead of "in a future version"
- Updates the `rf_frequency` deprecation warning to include the v0.6.0 removal notice
- Updates docstrings on all deprecated channel-level port properties to state "Will be removed in v0.6.0"
- Updates `docs/components/channels.md` and `docs/components/channel-ports.md` to reference v0.6.0 throughout
- Updates `CHANGELOG.md` deprecated entries to explicitly state v0.6.0 removal

## Background

Deprecated properties (`opx_output_offset`, `filter_fir_taps`, `filter_iir_taps`, `shareable`, `inverted`, `rf_frequency`, and their I/Q/input variants) were introduced and deprecated within the same v0.5.0 alpha cycle (PR #172). Users on stable v0.5.0 deserves a clear deprecation period before removal. This PR sets the removal target to v0.6.0.

Related: PR #195 contains the actual removal (to be merged after v0.6.0 is tagged).

## Test plan

- [ ] All existing tests pass (`627 passed`)
- [ ] No new deprecation warnings introduced
- [ ] Documentation renders correctly with updated version references