### PR TITLE
Fix octave calibration: populate IF_outputs when channel is connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `OctaveDownConverter.apply_to_config` to always add `IF_outputs` (physical port wiring) to the QUA config whenever a channel is connected, regardless of whether `LO_frequency` is set. This resolves a bug where `qm.calibrate_element()` failed silently because the calibration connections could not be found in the config.
+
 ### Added
 
 - Added `Channel.ramp(slope, duration)` method for playing linear voltage ramps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## [Unreleased]
 
-### Fixed
-
-- Fixed `OctaveDownConverter.apply_to_config` to always add `IF_outputs` (physical port wiring) to the QUA config whenever a channel is connected, regardless of whether `LO_frequency` is set. This resolves a bug where `qm.calibrate_element()` failed silently because the calibration connections could not be found in the config.
-
 ### Added
 
 - Added `Channel.ramp(slope, duration)` method for playing linear voltage ramps
@@ -61,6 +57,7 @@ All deprecated properties now show migration guidance with code examples. See [P
   - Improved error handling in `QuamList.__getitem__` and `QuamDict.__getitem__` for chain resolution failures
 - Fixed passing follow_references and include_defaults kwar
 - Fixed project-specific config not recognizing QUAM state path if the main config doesn't have a QUAM state path
+- Fixed `OctaveDownConverter.apply_to_config` to always add `IF_outputs` (physical port wiring) to the QUA config whenever a channel is connected, regardless of whether `LO_frequency` is set. This resolves a bug where `qm.calibrate_element()` failed silently because the calibration connections could not be found in the config.
 
 ## [0.4.2]
 

--- a/quam/components/octave.py
+++ b/quam/components/octave.py
@@ -383,13 +383,15 @@ class OctaveDownConverter(OctaveFrequencyConverter):
                 zip(IF_channels, opx_port_tuples), start=1
             ):
                 label = f"IF_out{IF_ch}"
-                IF_config.setdefault(label, {"port": opx_port_tuple, "name": f"out{k}"})
-                if IF_config[label]["port"] != opx_port_tuple:
+                entry = IF_config.setdefault(
+                    label, {"port": opx_port_tuple, "name": f"out{k}"}
+                )
+                if entry["port"] != opx_port_tuple:
                     raise ValueError(
                         f"Error generating config for Octave downconverter "
                         f"id={self.id}: Unable to assign {label} to port "
                         f"{opx_port_tuple} because it is already assigned to "
-                        f"port {IF_config[label]['port']} "
+                        f"port {entry['port']}"
                     )
 
         # RF_inputs entry requires LO_frequency — skip if not yet configured

--- a/quam/components/octave.py
+++ b/quam/components/octave.py
@@ -339,29 +339,62 @@ class OctaveDownConverter(OctaveFrequencyConverter):
         This method is called by the `QuamComponent.generate_config` method.
 
         Nothing is added to the config if the `OctaveDownConverter.channel` is not
-        specified or if the `OctaveDownConverter.LO_frequency` is not specified.
+        specified. If `channel` is specified but `LO_frequency` is not, the
+        `IF_outputs` (physical port wiring) are still added to enable element
+        calibration, but the `RF_inputs` logical config entry is omitted.
 
         Args:
             config: A dictionary representing a QUA config file.
 
         Raises:
-            ValueError: If the LO_frequency is not specified.
             KeyError: If the Octave is not in the config, or if config["octaves"] does
                 not exist.
             KeyError: If the Octave already has an entry for the OctaveDownConverter.
             ValueError: If the IF_output_I and IF_output_Q are already assigned to
                 other ports.
         """
-        if not isinstance(self.LO_frequency, (int, float)):
-            if self.channel is None:
-                return
-            else:
-                raise ValueError(
-                    f"Error generating config for Octave upconverter id={self.id}: "
-                    "LO_frequency must be specified."
-                )
+        # Nothing to add if neither channel nor LO_frequency is configured
+        if self.channel is None and not isinstance(self.LO_frequency, (int, float)):
+            return
 
         super().apply_to_config(config)
+
+        # Add IF_outputs (physical wiring) whenever channel is connected.
+        # This is required for qm.calibrate_element() to find calibration connections,
+        # independent of whether LO_frequency has been configured.
+        if self.channel is not None:
+            if isinstance(self.channel, InOutIQChannel):
+                IF_channels = [self.IF_output_I, self.IF_output_Q]
+                opx_channels = [self.channel.opx_input_I, self.channel.opx_input_Q]
+            elif isinstance(self.channel, InOutSingleChannel):
+                IF_channels = [self.IF_output_I]
+                opx_channels = [self.channel.opx_input]
+            else:
+                IF_channels = []
+                opx_channels = []
+
+            opx_port_tuples = [
+                p.port_tuple if isinstance(p, BasePort) else tuple(p)
+                for p in opx_channels
+            ]
+
+            IF_config = config["octaves"][self.octave.name]["IF_outputs"]
+            for k, (IF_ch, opx_port_tuple) in enumerate(
+                zip(IF_channels, opx_port_tuples), start=1
+            ):
+                label = f"IF_out{IF_ch}"
+                IF_config.setdefault(label, {"port": opx_port_tuple, "name": f"out{k}"})
+                if IF_config[label]["port"] != opx_port_tuple:
+                    raise ValueError(
+                        f"Error generating config for Octave downconverter "
+                        f"id={self.id}: Unable to assign {label} to port "
+                        f"{opx_port_tuple} because it is already assigned to "
+                        f"port {IF_config[label]['port']} "
+                    )
+
+        # RF_inputs entry requires LO_frequency — skip if not yet configured
+        if not isinstance(self.LO_frequency, (int, float)):
+            return
 
         if self.id in config["octaves"][self.octave.name]["RF_inputs"]:
             raise KeyError(
@@ -377,33 +410,6 @@ class OctaveDownConverter(OctaveFrequencyConverter):
             "IF_mode_I": self.IF_mode_I,
             "IF_mode_Q": self.IF_mode_Q,
         }
-
-        if isinstance(self.channel, InOutIQChannel):
-            IF_channels = [self.IF_output_I, self.IF_output_Q]
-            opx_channels = [self.channel.opx_input_I, self.channel.opx_input_Q]
-        elif isinstance(self.channel, InOutSingleChannel):
-            IF_channels = [self.IF_output_I]
-            opx_channels = [self.channel.opx_input]
-        else:
-            IF_channels = []
-            opx_channels = []
-
-        opx_port_tuples = [
-            p.port_tuple if isinstance(p, BasePort) else tuple(p) for p in opx_channels
-        ]
-
-        IF_config = config["octaves"][self.octave.name]["IF_outputs"]
-        for k, (IF_ch, opx_port_tuples) in enumerate(
-            zip(IF_channels, opx_port_tuples), start=1
-        ):
-            label = f"IF_out{IF_ch}"
-            IF_config.setdefault(label, {"port": opx_port_tuples, "name": f"out{k}"})
-            if IF_config[label]["port"] != opx_port_tuples:
-                raise ValueError(
-                    f"Error generating config for Octave downconverter id={self.id}: "
-                    f"Unable to assign {label} to  port {opx_port_tuples} because it is already "
-                    f"assigned to port {IF_config[label]['port']} "
-                )
 
 
 @quam_dataclass

--- a/tests/components/test_octave.py
+++ b/tests/components/test_octave.py
@@ -248,6 +248,59 @@ def test_frequency_down_converter_with_single_channel_apply_to_config(octave):
     assert cfg == expected_cfg
 
 
+def test_frequency_down_converter_channel_no_lo_adds_if_outputs(octave):
+    """Channel connected without LO_frequency should still add IF_outputs for calibration."""
+    channel = InOutIQChannel(
+        opx_output_I=("con1", 3),
+        opx_output_Q=("con1", 4),
+        opx_input_I=("con1", 1),
+        opx_input_Q=("con1", 2),
+        frequency_converter_up=None,
+        frequency_converter_down=None,
+    )
+    converter = octave.RF_inputs[1] = OctaveDownConverter(
+        id=1, LO_frequency=None, channel=channel
+    )
+    cfg = {}
+    octave.apply_to_config(config=cfg)
+    converter.apply_to_config(cfg)
+
+    expected_cfg = {
+        "octaves": {
+            "octave1": {
+                "RF_outputs": {},
+                "RF_inputs": {},
+                "IF_outputs": {
+                    "IF_out1": {"port": ("con1", 1), "name": "out1"},
+                    "IF_out2": {"port": ("con1", 2), "name": "out2"},
+                },
+                "loopbacks": [],
+            }
+        }
+    }
+    assert cfg == expected_cfg
+
+
+def test_frequency_down_converter_no_channel_no_lo_adds_nothing(octave):
+    """No channel and no LO_frequency: nothing should be added to the config."""
+    converter = octave.RF_inputs[1] = OctaveDownConverter(id=1, LO_frequency=None)
+    cfg = {}
+    octave.apply_to_config(config=cfg)
+    converter.apply_to_config(cfg)
+
+    expected_cfg = {
+        "octaves": {
+            "octave1": {
+                "RF_outputs": {},
+                "RF_inputs": {},
+                "IF_outputs": {},
+                "loopbacks": [],
+            }
+        }
+    }
+    assert cfg == expected_cfg
+
+
 def test_instantiate_octave_default_connectivity(octave):
     octave.initialize_frequency_converters()
 


### PR DESCRIPTION
## Summary

- `OctaveDownConverter.apply_to_config` previously only added `IF_outputs` to the QUA config when both `channel` and `LO_frequency` were set
- `IF_outputs` represents physical port wiring (which Octave IF output → which OPX ADC input) and is independent of LO configuration
- Without `IF_outputs` in the config, `qm.calibrate_element()` silently finds no calibration connections and produces no calibration elements

Fixes #162.

## Root cause

`qm-qua`'s `prep_config_for_calibration` reads `IF_outputs` from the QUA config to discover ADC port connections. If a user sets up the channel connection but hasn't configured `LO_frequency` (which defaults to `None`), the old code returned early and left `IF_outputs` absent from the config entirely.

## Changes

`OctaveDownConverter.apply_to_config` now decouples physical wiring from logical RF config:

| `channel` | `LO_frequency` | Before | After |
|---|---|---|---|
| None | None | nothing added | nothing added (unchanged) |
| None | set | `RF_inputs` only | `RF_inputs` only (unchanged) |
| set | None | `ValueError` raised | `IF_outputs` only **(fixed)** |
| set | set | both added | both added (unchanged) |

## Test plan

- [x] All 629 existing tests pass
- [x] New test: channel connected without `LO_frequency` adds `IF_outputs` but not `RF_inputs`
- [x] New test: no channel and no `LO_frequency` adds nothing