### PR TITLE
Docs: clarify kwargs vs attributes for method macros (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ All deprecated properties now show migration guidance with code examples. See [P
 
 ### Fixed
 
+- Clarified in documentation how kwargs and attributes differ for method macros: kwargs are per-call overrides, attributes are persistent calibrated values that are saved with the QUAM state
+
 - Improved error messages for inferred frequency properties (`inferred_RF_frequency`, `inferred_intermediate_frequency`, `inferred_LO_frequency`) in `_OutComplexChannel` (`IQChannel` and `MWChannel`): errors now clearly identify the specific field and whether it is `None` or an unresolved reference
 - Fixed config version mismatch error handling:
   - Separated error handling for config-too-old vs package-too-old scenarios

--- a/docs/features/gate-level-operations.md
+++ b/docs/features/gate-level-operations.md
@@ -473,14 +473,17 @@ Method macros provide better code organization by keeping qubit-specific logic w
 
 ### Kwargs vs. attributes in method macros
 
-A common question when writing method macros is: should a parameter like `threshold` be a **keyword argument** on the method, or an **attribute** on the qubit (or `QuamMacro` subclass)?
+A common question when writing method macros is: should a calibration parameter like `threshold` be a **keyword argument** on the method, or stored somewhere as a persistent attribute? And if an attribute, where?
 
-The rule is straightforward:
+The rule for kwargs is straightforward:
 
-- **Attributes** are *persistent calibrated values*. They are stored in the QUAM state, saved to disk, and loaded back when you restore a session. Use these for parameters that come from a calibration and should remain consistent across many experiments.
-- **Kwargs** are *one-time per-call overrides*. They are not stored anywhere and disappear after the call returns. Use these when you need to deviate from the calibrated value for a single program or experiment.
+- **Kwargs** are *one-time per-call overrides*. They are not stored anywhere and disappear after the call returns. Use these when you need to deviate from a calibrated value for a single program or experiment.
 
-**Example: threshold as an attribute**
+For persistent calibrated values you have three options depending on how tightly the parameter is coupled to the macro:
+
+**Option 1 — Attribute on the qubit (method macro)**
+
+If the parameter is a general property of the qubit (e.g., a readout threshold used across several macros), add it as a dataclass field on the qubit class itself. Method macros access it via `self`:
 
 ```python
 @quam_dataclass
@@ -499,34 +502,55 @@ class Transmon(Qubit):
         self.xy.wait(100)
 ```
 
-After calibration you store the result once:
+After calibration you store the result once and it is automatically used on every subsequent call:
 
 ```python
 q1.reset_threshold = 0.05   # persists across sessions when you call machine.save(...)
+
+with qua.program() as prog:
+    q1.apply("reset")                       # uses q1.reset_threshold = 0.05
+    q1.apply("reset", threshold=0.10)       # one-time override; q1.reset_threshold unchanged
 ```
 
-In the QUA program you just call the macro without any arguments — the calibrated value is used automatically:
+**Option 2 — Custom `QuamMacro` subclass**
+
+If the parameter is *specific to one macro* (not a general qubit property), create a dedicated `QuamMacro` subclass and store the attribute there. This keeps the qubit's namespace clean and makes the coupling explicit:
 
 ```python
-with qua.program() as prog:
-    q1.apply("reset")          # uses q1.reset_threshold = 0.05
+from quam.components.macro import QubitMacro
+
+@quam_dataclass
+class MeasureMacro(QubitMacro):
+    threshold: float  # belongs to this macro, not to the qubit in general
+
+    def apply(self, threshold: float = None, **kwargs):
+        t = threshold if threshold is not None else self.threshold
+        I, Q = self.qubit.resonator.measure("readout")
+        qubit_state = qua.declare(bool)
+        qua.assign(qubit_state, I > t)
+        return qubit_state
+
+# Attach to the qubit — the threshold is now part of the macro's state
+q1.macros["measure"] = MeasureMacro(threshold=0.215)
 ```
 
-You can still override it for a single call when needed:
+The threshold is stored on the macro object, saved with the QUAM state, and can be updated after calibration:
 
 ```python
-with qua.program() as prog:
-    q1.apply("reset", threshold=0.10)   # one-time override; q1.reset_threshold is unchanged
-```
+q1.macros["measure"].threshold = 0.18   # update after re-calibration
 
-The same pattern applies to `QuamMacro` subclasses stored in `qubit.macros`. For example, `MeasureMacro` stores `threshold` as a dataclass field (attribute), not as a keyword argument, because the threshold comes from readout calibration and must be saved with the state.
+with qua.program() as prog:
+    q1.apply("measure")                      # uses stored threshold 0.18
+    q1.apply("measure", threshold=0.10)      # one-time override
+```
 
 **Summary**
 
-| Use case | Mechanism | Persisted? |
-|----------|-----------|------------|
-| Calibrated parameter | dataclass field / attribute | Yes — saved with QUAM state |
-| Single-experiment override | keyword argument at call site | No — discarded after the call |
+| Use case | Mechanism | Persisted? | Best when… |
+|----------|-----------|------------|------------|
+| One-time deviation | kwarg at call site | No | Single experiment override |
+| General qubit property | field on the qubit class | Yes | Parameter shared across multiple macros |
+| Macro-specific parameter | field on a `QuamMacro` subclass | Yes | Parameter belongs to exactly one macro |
 
 ### Clifford macro
 

--- a/docs/features/gate-level-operations.md
+++ b/docs/features/gate-level-operations.md
@@ -471,6 +471,63 @@ print(q1.get_macros())  # {'reset': <MethodMacro 'reset'>, 'align': <MethodMacro
 
 Method macros provide better code organization by keeping qubit-specific logic within the qubit class itself, while still maintaining full compatibility with the QUAM macro system.
 
+### Kwargs vs. attributes in method macros
+
+A common question when writing method macros is: should a parameter like `threshold` be a **keyword argument** on the method, or an **attribute** on the qubit (or `QuamMacro` subclass)?
+
+The rule is straightforward:
+
+- **Attributes** are *persistent calibrated values*. They are stored in the QUAM state, saved to disk, and loaded back when you restore a session. Use these for parameters that come from a calibration and should remain consistent across many experiments.
+- **Kwargs** are *one-time per-call overrides*. They are not stored anywhere and disappear after the call returns. Use these when you need to deviate from the calibrated value for a single program or experiment.
+
+**Example: threshold as an attribute**
+
+```python
+@quam_dataclass
+class Transmon(Qubit):
+    xy: MWChannel
+    resonator: Optional[InOutMWChannel] = None
+    reset_threshold: float = 0.0  # calibrated value — persisted in state
+
+    @QuantumComponent.register_macro
+    def reset(self, threshold: float = None):
+        # Use the per-call override if provided, otherwise fall back to the calibrated value.
+        t = threshold if threshold is not None else self.reset_threshold
+        I, Q = self.resonator.measure("readout")
+        with qua.if_(I > t):
+            self.xy.play("x180")
+        self.xy.wait(100)
+```
+
+After calibration you store the result once:
+
+```python
+q1.reset_threshold = 0.05   # persists across sessions when you call machine.save(...)
+```
+
+In the QUA program you just call the macro without any arguments — the calibrated value is used automatically:
+
+```python
+with qua.program() as prog:
+    q1.apply("reset")          # uses q1.reset_threshold = 0.05
+```
+
+You can still override it for a single call when needed:
+
+```python
+with qua.program() as prog:
+    q1.apply("reset", threshold=0.10)   # one-time override; q1.reset_threshold is unchanged
+```
+
+The same pattern applies to `QuamMacro` subclasses stored in `qubit.macros`. For example, `MeasureMacro` stores `threshold` as a dataclass field (attribute), not as a keyword argument, because the threshold comes from readout calibration and must be saved with the state.
+
+**Summary**
+
+| Use case | Mechanism | Persisted? |
+|----------|-----------|------------|
+| Calibrated parameter | dataclass field / attribute | Yes — saved with QUAM state |
+| Single-experiment override | keyword argument at call site | No — discarded after the call |
+
 ### Clifford macro
 
 Next, we define a single-qubit "CliffordMacro". For illustration, we will define a few pulses


### PR DESCRIPTION
## Summary

- Adds a **Kwargs vs. attributes** subsection under *Method Macros* in `docs/features/gate-level-operations.md`
- Explains that dataclass fields are persistent calibrated values (saved with QUAM state), while keyword arguments are one-time per-call overrides
- Includes a concrete `reset` example and a summary table

Closes #190.

## Test plan

- [ ] `mkdocs serve` renders the new section correctly
- [ ] Code example in the new section is syntactically correct