### PR TITLE
Fix: add exponential_dc_gain and high_pass_filter to LFFEMAnalogOutputPort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All deprecated properties now show migration guidance with code examples. See [P
 
 ### Fixed
 
+- Added `exponential_dc_gain` and `high_pass_filter` fields to `LFFEMAnalogOutputPort` for QOP 3.5+ filter support; fixed validation so the two fields can coexist and `exponential_dc_gain` alone conflicts with `feedback_filter`
 - Fixed config version mismatch error handling:
   - Separated error handling for config-too-old vs package-too-old scenarios
   - Original version mismatch error was being masked by `ModuleNotFoundError` during migration

--- a/quam/components/ports/analog_outputs.py
+++ b/quam/components/ports/analog_outputs.py
@@ -55,19 +55,38 @@ class LFFEMAnalogOutputPort(LFAnalogOutputPort, FEMPort):
     sampling_rate: float = 1e9  # Either 1e9 or 2e9
     upsampling_mode: Literal["mw", "pulse"] = "mw"
     exponential_filter: Optional[List[Tuple[float, float]]] = None
-    # high_pass_filter: Optional[float] = None  # Not yet supported
+    exponential_dc_gain: Optional[float] = None
+    high_pass_filter: Optional[float] = None
     output_mode: Literal["direct", "amplified"] = "direct"
 
     def get_port_properties(self) -> Dict[str, Any]:
         port_properties = super().get_port_properties()
+
+        if self.exponential_dc_gain is not None and self.high_pass_filter is not None:
+            raise ValueError(
+                "LFFEMAnalogOutputPort: 'exponential_dc_gain' and 'high_pass_filter' "
+                "are mutually exclusive. Please specify only one."
+            )
+
+        if self.exponential_filter is not None or self.high_pass_filter is not None:
+            if self.feedback_filter is not None:
+                raise ValueError(
+                    "LFFEMAnalogOutputPort: Please only specify 'exponential_filter' / "
+                    "'high_pass_filter' if QOP >=3.3.0, or 'feedback_filter' if "
+                    "QOP < 3.3.0, not both"
+                )
+
         if self.exponential_filter is not None:
             filter_properties = port_properties.setdefault("filter", {})
             filter_properties["exponential"] = list(self.exponential_filter)
-            if "feedback" in filter_properties:
-                raise ValueError(
-                    "LFFEMAnalogOutputPort: Please only specify 'exponential_filter' "
-                    "if QOP >=3.3.0, or 'feedback_filter' if QOP < 3.3.0, not both"
-                )
+
+        if self.exponential_dc_gain is not None:
+            filter_properties = port_properties.setdefault("filter", {})
+            filter_properties["exponential_dc_gain"] = self.exponential_dc_gain
+
+        if self.high_pass_filter is not None:
+            filter_properties = port_properties.setdefault("filter", {})
+            filter_properties["high_pass"] = self.high_pass_filter
 
         port_properties["sampling_rate"] = self.sampling_rate
         if self.sampling_rate == 1e9:

--- a/quam/components/ports/analog_outputs.py
+++ b/quam/components/ports/analog_outputs.py
@@ -62,17 +62,15 @@ class LFFEMAnalogOutputPort(LFAnalogOutputPort, FEMPort):
     def get_port_properties(self) -> Dict[str, Any]:
         port_properties = super().get_port_properties()
 
-        if self.exponential_dc_gain is not None and self.high_pass_filter is not None:
-            raise ValueError(
-                "LFFEMAnalogOutputPort: 'exponential_dc_gain' and 'high_pass_filter' "
-                "are mutually exclusive. Please specify only one."
-            )
-
-        if self.exponential_filter is not None or self.high_pass_filter is not None:
+        if (
+            self.exponential_filter is not None
+            or self.high_pass_filter is not None
+            or self.exponential_dc_gain is not None
+        ):
             if self.feedback_filter is not None:
                 raise ValueError(
                     "LFFEMAnalogOutputPort: Please only specify 'exponential_filter' / "
-                    "'high_pass_filter' if QOP >=3.3.0, or 'feedback_filter' if "
+                    "'high_pass_filter' / 'exponential_dc_gain' if QOP >=3.3.0, or 'feedback_filter' if "
                     "QOP < 3.3.0, not both"
                 )
 

--- a/tests/components/ports/test_lf_fem_analog_ports.py
+++ b/tests/components/ports/test_lf_fem_analog_ports.py
@@ -210,7 +210,7 @@ def test_lf_fem_analog_output_port_exponential_filter():
 
     # Adding feedback filter should raise ValueError due to QOP version compatibility
     port.feedback_filter = [0.3, 0.4, 0.5]
-    with pytest.raises(ValueError, match="Please only specify 'exponential_filter' "):
+    with pytest.raises(ValueError, match="'exponential_filter' / 'high_pass_filter'"):
         port.get_port_properties()
     # Remove exponential filter and verify feedback filter works
     port.exponential_filter = None
@@ -223,3 +223,64 @@ def test_lf_fem_analog_output_port_exponential_filter():
         "upsampling_mode": "mw",
         "filter": {"feedforward": [0.7, 0.2, 0.1], "feedback": [0.3, 0.4, 0.5]},
     }
+
+
+def test_lf_fem_analog_output_port_exponential_dc_gain():
+    port = LFFEMAnalogOutputPort("con1", 1, 2)
+    port.exponential_filter = [(10, 0.1), (20, 0.2)]
+    port.exponential_dc_gain = 0.5
+
+    assert port.get_port_properties() == {
+        "delay": 0,
+        "shareable": False,
+        "output_mode": "direct",
+        "sampling_rate": 1e9,
+        "upsampling_mode": "mw",
+        "filter": {
+            "exponential": [(10, 0.1), (20, 0.2)],
+            "exponential_dc_gain": 0.5,
+        },
+    }
+
+    # exponential_dc_gain without exponential_filter is also valid
+    port.exponential_filter = None
+    assert port.get_port_properties() == {
+        "delay": 0,
+        "shareable": False,
+        "output_mode": "direct",
+        "sampling_rate": 1e9,
+        "upsampling_mode": "mw",
+        "filter": {"exponential_dc_gain": 0.5},
+    }
+
+
+def test_lf_fem_analog_output_port_high_pass_filter():
+    port = LFFEMAnalogOutputPort("con1", 1, 2)
+    port.high_pass_filter = 1e-3
+
+    assert port.get_port_properties() == {
+        "delay": 0,
+        "shareable": False,
+        "output_mode": "direct",
+        "sampling_rate": 1e9,
+        "upsampling_mode": "mw",
+        "filter": {"high_pass": 1e-3},
+    }
+
+
+def test_lf_fem_analog_output_port_exponential_dc_gain_and_high_pass_mutually_exclusive():
+    port = LFFEMAnalogOutputPort("con1", 1, 2)
+    port.exponential_dc_gain = 0.5
+    port.high_pass_filter = 1e-3
+
+    with pytest.raises(ValueError, match="'exponential_dc_gain' and 'high_pass_filter'"):
+        port.get_port_properties()
+
+
+def test_lf_fem_analog_output_port_high_pass_and_feedback_mutually_exclusive():
+    port = LFFEMAnalogOutputPort("con1", 1, 2)
+    port.high_pass_filter = 1e-3
+    port.feedback_filter = [0.3, 0.4]
+
+    with pytest.raises(ValueError, match="'exponential_filter' / 'high_pass_filter'"):
+        port.get_port_properties()

--- a/tests/components/ports/test_lf_fem_analog_ports.py
+++ b/tests/components/ports/test_lf_fem_analog_ports.py
@@ -210,7 +210,7 @@ def test_lf_fem_analog_output_port_exponential_filter():
 
     # Adding feedback filter should raise ValueError due to QOP version compatibility
     port.feedback_filter = [0.3, 0.4, 0.5]
-    with pytest.raises(ValueError, match="'exponential_filter' / 'high_pass_filter'"):
+    with pytest.raises(ValueError, match="'exponential_filter' / 'high_pass_filter' / 'exponential_dc_gain'"):
         port.get_port_properties()
     # Remove exponential filter and verify feedback filter works
     port.exponential_filter = None
@@ -268,12 +268,27 @@ def test_lf_fem_analog_output_port_high_pass_filter():
     }
 
 
-def test_lf_fem_analog_output_port_exponential_dc_gain_and_high_pass_mutually_exclusive():
+def test_lf_fem_analog_output_port_exponential_dc_gain_with_high_pass():
     port = LFFEMAnalogOutputPort("con1", 1, 2)
     port.exponential_dc_gain = 0.5
     port.high_pass_filter = 1e-3
 
-    with pytest.raises(ValueError, match="'exponential_dc_gain' and 'high_pass_filter'"):
+    assert port.get_port_properties() == {
+        "delay": 0,
+        "shareable": False,
+        "output_mode": "direct",
+        "sampling_rate": 1e9,
+        "upsampling_mode": "mw",
+        "filter": {"exponential_dc_gain": 0.5, "high_pass": 1e-3},
+    }
+
+
+def test_lf_fem_analog_output_port_exponential_dc_gain_and_feedback_mutually_exclusive():
+    port = LFFEMAnalogOutputPort("con1", 1, 2)
+    port.exponential_dc_gain = 0.5
+    port.feedback_filter = [0.3, 0.4]
+
+    with pytest.raises(ValueError, match="'exponential_filter' / 'high_pass_filter' / 'exponential_dc_gain'"):
         port.get_port_properties()
 
 
@@ -282,5 +297,5 @@ def test_lf_fem_analog_output_port_high_pass_and_feedback_mutually_exclusive():
     port.high_pass_filter = 1e-3
     port.feedback_filter = [0.3, 0.4]
 
-    with pytest.raises(ValueError, match="'exponential_filter' / 'high_pass_filter'"):
+    with pytest.raises(ValueError, match="'exponential_filter' / 'high_pass_filter' / 'exponential_dc_gain'"):
         port.get_port_properties()


### PR DESCRIPTION
Closes #189

## Summary

- Adds `exponential_dc_gain: Optional[float]` and `high_pass_filter: Optional[float]` to `LFFEMAnalogOutputPort`, exposing the QOP 3.5+ IIR filter config keys that were previously missing
- `exponential_dc_gain` maps to `filter.exponential_dc_gain`; `high_pass_filter` maps to `filter.high_pass`
- Validates that neither field is used together with `feedback_filter` (which belongs to pre-QOP 3.3)
- `exponential_dc_gain` and `high_pass_filter` can coexist (as permitted by the SDK — using `high_pass` without `exponential_dc_gain` on QOP 3.5+ emits a deprecation warning from the SDK, but is not an error)

## Test plan

- [ ] `test_lf_fem_analog_output_port_exponential_dc_gain` — new field produces correct config key
- [ ] `test_lf_fem_analog_output_port_high_pass_filter` — new field produces correct config key
- [ ] `test_lf_fem_analog_output_port_exponential_dc_gain_with_high_pass` — both fields coexist correctly
- [ ] `test_lf_fem_analog_output_port_exponential_dc_gain_and_feedback_mutually_exclusive` — raises when mixed with `feedback_filter`
- [ ] `test_lf_fem_analog_output_port_high_pass_and_feedback_mutually_exclusive` — raises when mixed with `feedback_filter`
- [ ] All existing LF-FEM port tests continue to pass