### PR TITLE
Add Python 3.13 and 3.14 support, drop Python 3.9

### DIFF
--- a/.github/workflows/quam_test.yaml
+++ b/.github/workflows/quam_test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/quam_test.yaml
+++ b/.github/workflows/quam_test.yaml
@@ -10,15 +10,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-        matrix:
-          python-version: [3.9, 3.11, 3.12]
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -31,27 +31,8 @@ jobs:
       if: always()
       uses: pmeier/pytest-results-action@main
       with:
-        # A list of JUnit XML files, directories containing the former, and wildcard
-        # patterns to process.
-        # See @actions/glob for supported patterns.
         path: pytest-report.xml
-
-        # (Optional) Add a summary of the results at the top of the report
         summary: true
-
-        # (Optional) Select which results should be included in the report.
-        # Follows the same syntax as `pytest -r`
         display-options: fEX
-
-        # (Optional) Fail the workflow if no JUnit XML was found.
         fail-on-empty: true
-
-        # (Optional) Title of the test results section in the workflow summary
         title: Test results
-  
-    # - name: Upload pytest report as an artifact
-    #   if: success() || failure()
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: pytest-report-${{ matrix.python-version }}
-    #     path: pytest-report.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Serwan Asaad", email = "serwan.asaad@quantum-machines.co" },
 ]
 license = { text = "BSD-3-Clause" }
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.10,<3.14"
 readme = "README.md"
 
 classifiers = [
@@ -32,11 +32,9 @@ keywords = [
 ]
 
 dependencies = [
-    "numpy >= 1.21.2 ; python_version < '3.14'",
-    "numpy >= 2.4.4 ; python_version >= '3.14'",
+    "numpy >= 1.21.2",
     "scipy",
-    "qm-qua >=1.2.3 ; python_version < '3.14'",
-    "qm-qua >=1.3.0a1 ; python_version >= '3.14'",
+    "qm-qua >=1.2.3",
     "typeguard >= 4.1.0",
     "qualibrate-config >= 0.1.6",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Serwan Asaad", email = "serwan.asaad@quantum-machines.co" },
 ]
 license = { text = "BSD-3-Clause" }
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.10,<3.15"
 readme = "README.md"
 
 classifiers = [
@@ -32,8 +32,10 @@ keywords = [
 ]
 
 dependencies = [
-    "numpy >= 1.21.2",
-    "qm-qua >=1.2.3",
+    "numpy >= 1.21.2 ; python_version < '3.14'",
+    "numpy >= 2.4.4 ; python_version >= '3.14'",
+    "qm-qua >=1.2.3 ; python_version < '3.14'",
+    "qm-qua >=1.3.0a1 ; python_version >= '3.14'",
     "qualang-tools >= 0.15.0",
     "typeguard >= 4.1.0",
     "qualibrate-config >= 0.1.6",
@@ -59,7 +61,7 @@ docs = ["mkdocstrings[python]>=0.18", "mkdocs-gen-files", "mkdocs-jupyter"]
 build = ["setuptools >= 71", "setuptools-scm >= 8.1.0", "build >= 1.2.1"]
 
 [tool.black]
-target-version = ["py39"]
+target-version = ["py310"]
 line-length = 88
 preview = true
 


### PR DESCRIPTION
- Bump requires-python to >=3.10,<3.15
- Add Python version markers for numpy (>=2.4.4 on 3.14) and qm-qua (>=1.3.0a1 on 3.14) to ensure compatible wheels are resolved
- Update CI matrix to test 3.10–3.14, remove 3.9
- Update black target-version to py310