### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -22,7 +22,7 @@ on:
         description: "Python versions to test (JSON array, e.g. '[\"3.11\", \"3.12\"]')"
         required: false
         type: string
-        default: '["3.10", "3.11", "3.12", "3.13"]'
+        default: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       operating_systems:
         description: "Operating systems to test (JSON array, e.g. '[\"ubuntu-latest\", \"macos-latest\"]')"
         required: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Serwan Asaad", email = "serwan.asaad@quantum-machines.co" },
 ]
 license = { text = "BSD-3-Clause" }
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 readme = "README.md"
 
 classifiers = [


### PR DESCRIPTION
## Summary
- Bump `requires-python` upper bound from `<3.14` to `<3.15` in `pyproject.toml`
- Add `"3.14"` to the CI test matrix default in `.github/workflows/run_tests.yaml`

## Notes
- Actual 3.14 viability depends on whether the runtime deps (`numpy`, `scipy`, `qm-qua`, `typeguard`, `qualibrate-config`) ship 3.14-compatible wheels — the CI run on this PR will confirm.
- `[tool.black] target-version = ["py310"]` left unchanged (it's the minimum target, not a cap).
- The build workflow (`reusable-build.yaml`) still builds on 3.9 — that's the build host only, unrelated to runtime support, so left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)