### PR TITLE
Release v0.6.0

### DIFF
--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.12"
           cache: "pip"
 
       - name: Install python deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 ## [Unreleased]
 
+## [v0.6.0]
+
 ### Added
 
 - Added `__package_versions__` to saved JSON configs, recording the installed versions of all packages used to build the config.
 - Added `lo_mode` field to `MWFEMAnalogInputPort` (`Optional[Literal["auto", "always_on"]]`, defaults to `None`). When set, the value is passed through to the QUA config, allowing users to override the QOP default.
+- Added support for Python 3.13 and 3.14.
 
 ### Deprecated
 
@@ -19,6 +22,10 @@
 ### Changed
 
 - Removed `qualang-tools` as a runtime dependency. Waveform and integration-weight functions are now vendored in `quam/components/_waveform_tools.py`. Added `scipy` as a direct dependency.
+
+### Removed
+
+- Removed support for Python 3.9.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -57,7 +57,7 @@ dev = [
     "qm-saas",
 ]
 docs = ["mkdocstrings[python]>=0.18", "mkdocs-gen-files", "mkdocs-jupyter"]
-build = ["setuptools >= 71", "build >= 1.2.1"]
+build = ["setuptools >= 71", "setuptools-scm >= 8.1.0", "build >= 1.2.1"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -104,6 +104,10 @@ max-line-length = 88
 
 [tool.setuptools]
 packages = ["quam"]
+
+[tool.setuptools_scm]
+version_scheme = "only-version"
+local_scheme = "no-local-version"
 
 [tool.uv]
 prerelease = "allow"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quam"
-version = "0.5.0"
+version = "0.6.0"
 description = "Quantum Abstract Machine (QUAM) facilitates development of abstraction layers in experiments."
 authors = [
     { name = "Serwan Asaad", email = "serwan.asaad@quantum-machines.co" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -57,7 +57,7 @@ dev = [
     "qm-saas",
 ]
 docs = ["mkdocstrings[python]>=0.18", "mkdocs-gen-files", "mkdocs-jupyter"]
-build = ["setuptools >= 71", "setuptools-scm >= 8.1.0", "build >= 1.2.1"]
+build = ["setuptools >= 71", "build >= 1.2.1"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -104,10 +104,6 @@ max-line-length = 88
 
 [tool.setuptools]
 packages = ["quam"]
-
-[tool.setuptools_scm]
-version_scheme = "only-version"
-local_scheme = "no-local-version"
 
 [tool.uv]
 prerelease = "allow"


### PR DESCRIPTION
## Summary
Prepares the v0.6.0 release.

- Bump `version` to `0.6.0` in `pyproject.toml`
- Promote the `[Unreleased]` changelog section to `[v0.6.0]` (empty `[Unreleased]` retained on top, matching the prior release convention)
- Fix the release build: bump `reusable-build.yaml` Python from `3.9` → `3.12`

## Missing changelog entries added
Audited all PRs merged since the v0.5.0 changelog (`ffa137e`). The existing `[Unreleased]` section already covered #218 (`__package_versions__`), #211 (`lo_mode`), #210 (pulse deprecations + `qualang-tools` removal), and #209 (qualibrate save fix). The following were **missing** and have been added:

- **Added** — support for Python 3.13 and 3.14 (#214, #219)
- **Removed** — support for Python 3.9 (#214)

PRs that are CI/test/docs-only and do not warrant changelog entries (consistent with existing changelog style): #215, #216, #212, #207.

## Release build fix
`reusable-build.yaml` (used by both the draft-release and PyPI-publish workflows) pinned `setup-python` to `3.9`, but `requires-python` has been `>=3.10` since #214 dropped 3.9. `pip install -e .[build]` would abort on 3.9, breaking the release pipeline. Bumped to `3.12`; the wheel is `py3-none-any` so the artifact is equivalent on any supported version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Supersedes #220.