### PR TITLE
docs: fix hardcoded resonator output ports in demonstration.md

### DIFF
--- a/docs/demonstration.md
+++ b/docs/demonstration.md
@@ -63,8 +63,8 @@ for idx in range(num_qubits):
     # Add resonator channel
     transmon.resonator = InOutIQChannel(
         id=idx,
-        opx_output_I=("con1", 1),
-        opx_output_Q=("con1", 2),
+        opx_output_I=("con1", 3 * idx + 1),
+        opx_output_Q=("con1", 3 * idx + 2),
         opx_input_I=("con1", 1),
         opx_input_Q=("con1", 2,),
         frequency_converter_up=FrequencyConverter(


### PR DESCRIPTION
## Summary

In `docs/demonstration.md`, the "Populating the Machine" example initializes each qubit's resonator inside a `for idx in range(num_qubits)` loop, but hardcoded the same output ports for every qubit:

```python
opx_output_I=("con1", 1),
opx_output_Q=("con1", 2),
```

This contradicts the `machine.print_summary()` output shown further down in the same doc, which reports distinct ports per qubit: `q0` has `('con1', 1)/('con1', 2)` and `q1` has `('con1', 4)/('con1', 5)` — i.e. `3 * idx + 1` / `3 * idx + 2`, matching the pattern already used for the `xy` and `z` channels a few lines above.

## Fix

- `opx_output_I=("con1", 1)` → `opx_output_I=("con1", 3 * idx + 1)`
- `opx_output_Q=("con1", 2)` → `opx_output_Q=("con1", 3 * idx + 2)`

`opx_input_I`/`opx_input_Q` are left unchanged as `("con1", 1)`/`("con1", 2)`, since those are intentionally shared across qubits.

## Test plan

- [x] Diffed against the `machine.print_summary()` output later in the same doc to confirm the formula produces the shown ports for q0 and q1.