### PR TITLE
Fix mypy type error in MWFEMAnalogInputPort.get_port_properties

### DIFF
--- a/quam/components/ports/analog_inputs.py
+++ b/quam/components/ports/analog_inputs.py
@@ -59,7 +59,7 @@ class MWFEMAnalogInputPort(FEMPort):
     lo_mode: Optional[Literal["auto", "always_on"]] = None  # None defers to QUA default
 
     def get_port_properties(self) -> Dict[str, Any]:
-        port_properties = {
+        port_properties: Dict[str, Any] = {
             "band": self.band,
             "downconverter_frequency": self.downconverter_frequency,
             "sampling_rate": self.sampling_rate,


### PR DESCRIPTION
## Summary
- Fixes a pre-existing mypy error in `quam/components/ports/analog_inputs.py` that fails the `lint` job's `mypy` step on every PR (e.g. [run 30467312812](https://github.com/qua-platform/quam/actions/runs/30467312812/job/90628316674?pr=223)).
- The error was introduced in #211 (adding `lo_mode`), but only started failing CI once #217 added the mypy check to the lint job. `port_properties` was an untyped dict literal, so mypy inferred its value type from the initial int/float/bool entries (joining to `float`), then rejected the later `lo_mode: Literal["auto", "always_on"]` assignment. Annotating it as `Dict[str, Any]` (matching the function's own declared return type) fixes it — no behavior change.

## Test plan
- [x] `mypy quam/ --ignore-missing-imports --follow-imports=silent` — 0 errors (was 1)
- [x] `black --check quam/` — unchanged, passes
- [x] `pflake8 quam/` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSjkz5MSzwofzPG8vKfcA2